### PR TITLE
[RELEASE] v0.14 updates and changes

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -1,12 +1,9 @@
 # Versions for site
 #
 # NOTE: Must use "" to prevent loosing data like 0.10 -> 0.1
-legacy-version: "0.12"
-legacy-docs: "0.12.0"
-legacy-date: "FEB 2020"
-stable-version: "0.13"
-stable-docs: "0.13.0"
-stable-date: "MAR 2020"
-nightly-version: "0.14"
-nightly-docs: "0.14.0"
-nightly-date: "MAY 2020"
+legacy-version: "0.13"
+legacy-date: "MAR 2020"
+stable-version: "0.14"
+stable-date: "JUN 2020"
+nightly-version: "0.15"
+nightly-date: "AUG 2020"

--- a/_includes/options.html
+++ b/_includes/options.html
@@ -264,113 +264,113 @@ function CopyToClipboard(containerid) {
 -->
 <!-- dev - ubuntu 16.04 -->
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.2-devel-ubuntu16.04-py3.6
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.2-devel-ubuntu16.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.2-devel-ubuntu16.04-py3.6
+    rapidsai/rapidsai-dev:0.14-cuda10.2-devel-ubuntu16.04-py3.6
 ```
 {: .stable-all-dev-ubuntu1604-py36-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.2-devel-ubuntu16.04-py3.7
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.2-devel-ubuntu16.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.2-devel-ubuntu16.04-py3.7
+    rapidsai/rapidsai-dev:0.14-cuda10.2-devel-ubuntu16.04-py3.7
 ```
 {: .stable-all-dev-ubuntu1604-py37-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.0-devel-ubuntu16.04-py3.6
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.0-devel-ubuntu16.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.0-devel-ubuntu16.04-py3.6
+    rapidsai/rapidsai-dev:0.14-cuda10.0-devel-ubuntu16.04-py3.6
 ```
 {: .stable-all-dev-ubuntu1604-py36-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.0-devel-ubuntu16.04-py3.7
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.0-devel-ubuntu16.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.0-devel-ubuntu16.04-py3.7
+    rapidsai/rapidsai-dev:0.14-cuda10.0-devel-ubuntu16.04-py3.7
 ```
 {: .stable-all-dev-ubuntu1604-py37-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu16.04-py3.6
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.1-devel-ubuntu16.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu16.04-py3.6
+    rapidsai/rapidsai-dev:0.14-cuda10.1-devel-ubuntu16.04-py3.6
 ```
 {: .stable-all-dev-ubuntu1604-py36-cuda101 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu16.04-py3.7
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.1-devel-ubuntu16.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu16.04-py3.7
+    rapidsai/rapidsai-dev:0.14-cuda10.1-devel-ubuntu16.04-py3.7
 ```
 {: .stable-all-dev-ubuntu1604-py37-cuda101 .hidden }
 <!-- dev - ubuntu 18.04 -->
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.2-devel-ubuntu18.04-py3.6
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.2-devel-ubuntu18.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.2-devel-ubuntu18.04-py3.6
+    rapidsai/rapidsai-dev:0.14-cuda10.2-devel-ubuntu18.04-py3.6
 ```
 {: .stable-all-dev-ubuntu1804-py36-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.2-devel-ubuntu18.04-py3.7
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.2-devel-ubuntu18.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.2-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-dev:0.14-cuda10.2-devel-ubuntu18.04-py3.7
 ```
 {: .stable-all-dev-ubuntu1804-py37-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.0-devel-ubuntu18.04-py3.6
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.0-devel-ubuntu18.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.0-devel-ubuntu18.04-py3.6
+    rapidsai/rapidsai-dev:0.14-cuda10.0-devel-ubuntu18.04-py3.6
 ```
 {: .stable-all-dev-ubuntu1804-py36-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.0-devel-ubuntu18.04-py3.7
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.0-devel-ubuntu18.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.0-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-dev:0.14-cuda10.0-devel-ubuntu18.04-py3.7
 ```
 {: .stable-all-dev-ubuntu1804-py37-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu18.04-py3.6
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.1-devel-ubuntu18.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu18.04-py3.6
+    rapidsai/rapidsai-dev:0.14-cuda10.1-devel-ubuntu18.04-py3.6
 ```
 {: .stable-all-dev-ubuntu1804-py36-cuda101 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu18.04-py3.7
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.1-devel-ubuntu18.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-dev:0.14-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 {: .stable-all-dev-ubuntu1804-py37-cuda101 .hidden }
 <!-- dev - centos 7 -->
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.2-devel-centos7-py3.6
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.2-devel-centos7-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.2-devel-centos7-py3.6
+    rapidsai/rapidsai-dev:0.14-cuda10.2-devel-centos7-py3.6
 ```
 {: .stable-all-dev-centos7-py36-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.2-devel-centos7-py3.7
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.2-devel-centos7-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.2-devel-centos7-py3.7
+    rapidsai/rapidsai-dev:0.14-cuda10.2-devel-centos7-py3.7
 ```
 {: .stable-all-dev-centos7-py37-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.0-devel-centos7-py3.6
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.0-devel-centos7-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.0-devel-centos7-py3.6
+    rapidsai/rapidsai-dev:0.14-cuda10.0-devel-centos7-py3.6
 ```
 {: .stable-all-dev-centos7-py36-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.0-devel-centos7-py3.7
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.0-devel-centos7-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.0-devel-centos7-py3.7
+    rapidsai/rapidsai-dev:0.14-cuda10.0-devel-centos7-py3.7
 ```
 {: .stable-all-dev-centos7-py37-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.1-devel-centos7-py3.6
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.1-devel-centos7-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.1-devel-centos7-py3.6
+    rapidsai/rapidsai-dev:0.14-cuda10.1-devel-centos7-py3.6
 ```
 {: .stable-all-dev-centos7-py36-cuda101 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev:0.13-cuda10.1-devel-centos7-py3.7
+docker pull rapidsai/rapidsai-dev:0.14-cuda10.1-devel-centos7-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev:0.13-cuda10.1-devel-centos7-py3.7
+    rapidsai/rapidsai-dev:0.14-cuda10.1-devel-centos7-py3.7
 ```
 {: .stable-all-dev-centos7-py37-cuda101 .hidden }
 <!-- docker - ubuntu 16.04 -->
@@ -506,279 +506,279 @@ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
 <!-- conda cuda102 -->
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cudf=0.13 python=3.6 cudatoolkit=10.2
+    -c defaults cudf=0.14 python=3.6 cudatoolkit=10.2
 ```
 {: .stable-cudf-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cudf=0.13 python=3.7 cudatoolkit=10.2
+    -c defaults cudf=0.14 python=3.7 cudatoolkit=10.2
 ```
 {: .stable-cudf-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuml=0.13 python=3.6 cudatoolkit=10.2
+    -c defaults cuml=0.14 python=3.6 cudatoolkit=10.2
 ```
 {: .stable-cuml-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuml=0.13 python=3.7 cudatoolkit=10.2
+    -c defaults cuml=0.14 python=3.7 cudatoolkit=10.2
 ```
 {: .stable-cuml-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cugraph=0.13 python=3.6 cudatoolkit=10.2
+    -c defaults cugraph=0.14 python=3.6 cudatoolkit=10.2
 ```
 {: .stable-cugraph-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cugraph=0.13 python=3.7 cudatoolkit=10.2
+    -c defaults cugraph=0.14 python=3.7 cudatoolkit=10.2
 ```
 {: .stable-cugraph-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cusignal=0.13 python=3.6 cudatoolkit=10.2
+    -c defaults cusignal=0.14 python=3.6 cudatoolkit=10.2
 ```
 {: .stable-cusignal-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cusignal=0.13 python=3.7 cudatoolkit=10.2
+    -c defaults cusignal=0.14 python=3.7 cudatoolkit=10.2
 ```
 {: .stable-cusignal-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.13 python=3.6 cudatoolkit=10.2
+    -c defaults cuspatial=0.14 python=3.6 cudatoolkit=10.2
 ```
 {: .stable-cuspatial-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.13 python=3.7 cudatoolkit=10.2
+    -c defaults cuspatial=0.14 python=3.7 cudatoolkit=10.2
 ```
 {: .stable-cuspatial-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.13 python=3.6 cudatoolkit=10.2
+    -c defaults cuxfilter=0.14 python=3.6 cudatoolkit=10.2
 ```
 {: .stable-cuxfilter-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.13 python=3.7 cudatoolkit=10.2
+    -c defaults cuxfilter=0.14 python=3.7 cudatoolkit=10.2
 ```
 {: .stable-cuxfilter-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults rapids=0.13 python=3.6 cudatoolkit=10.2
+    -c defaults rapids=0.14 python=3.6 cudatoolkit=10.2
 ```
 {: .stable-all-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults rapids=0.13 python=3.7 cudatoolkit=10.2
+    -c defaults rapids=0.14 python=3.7 cudatoolkit=10.2
 ```
 {: .stable-all-conda-py37-cuda102 .hidden }
 
 <!-- conda cuda100 -->
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cudf=0.13 python=3.6 cudatoolkit=10.0
+    -c defaults cudf=0.14 python=3.6 cudatoolkit=10.0
 ```
 {: .stable-cudf-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cudf=0.13 python=3.7 cudatoolkit=10.0
+    -c defaults cudf=0.14 python=3.7 cudatoolkit=10.0
 ```
 {: .stable-cudf-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuml=0.13 python=3.6 cudatoolkit=10.0
+    -c defaults cuml=0.14 python=3.6 cudatoolkit=10.0
 ```
 {: .stable-cuml-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuml=0.13 python=3.7 cudatoolkit=10.0
+    -c defaults cuml=0.14 python=3.7 cudatoolkit=10.0
 ```
 {: .stable-cuml-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cugraph=0.13 python=3.6 cudatoolkit=10.0
+    -c defaults cugraph=0.14 python=3.6 cudatoolkit=10.0
 ```
 {: .stable-cugraph-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cugraph=0.13 python=3.7 cudatoolkit=10.0
+    -c defaults cugraph=0.14 python=3.7 cudatoolkit=10.0
 ```
 {: .stable-cugraph-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cusignal=0.13 python=3.6 cudatoolkit=10.0
+    -c defaults cusignal=0.14 python=3.6 cudatoolkit=10.0
 ```
 {: .stable-cusignal-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cusignal=0.13 python=3.7 cudatoolkit=10.0
+    -c defaults cusignal=0.14 python=3.7 cudatoolkit=10.0
 ```
 {: .stable-cusignal-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.13 python=3.6 cudatoolkit=10.0
+    -c defaults cuspatial=0.14 python=3.6 cudatoolkit=10.0
 ```
 {: .stable-cuspatial-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.13 python=3.7 cudatoolkit=10.0
+    -c defaults cuspatial=0.14 python=3.7 cudatoolkit=10.0
 ```
 {: .stable-cuspatial-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.13 python=3.6 cudatoolkit=10.0
+    -c defaults cuxfilter=0.14 python=3.6 cudatoolkit=10.0
 ```
 {: .stable-cuxfilter-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.13 python=3.7 cudatoolkit=10.0
+    -c defaults cuxfilter=0.14 python=3.7 cudatoolkit=10.0
 ```
 {: .stable-cuxfilter-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults clx=0.13 python=3.6 cudatoolkit=10.0
+    -c defaults clx=0.14 python=3.6 cudatoolkit=10.0
 ```
 {: .stable-clx-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults clx=0.13 python=3.7 cudatoolkit=10.0
+    -c defaults clx=0.14 python=3.7 cudatoolkit=10.0
 ```
 {: .stable-clx-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults rapids=0.13 python=3.6
+    -c defaults rapids=0.14 python=3.6
 ```
 {: .stable-all-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults rapids=0.13 python=3.7
+    -c defaults rapids=0.14 python=3.7
 ```
 {: .stable-all-conda-py37-cuda100 .hidden }
 
 <!-- conda cuda101 -->
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cudf=0.13 python=3.6 cudatoolkit=10.1
+    -c defaults cudf=0.14 python=3.6 cudatoolkit=10.1
 ```
 {: .stable-cudf-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cudf=0.13 python=3.7 cudatoolkit=10.1
+    -c defaults cudf=0.14 python=3.7 cudatoolkit=10.1
 ```
 {: .stable-cudf-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuml=0.13 python=3.6 cudatoolkit=10.1
+    -c defaults cuml=0.14 python=3.6 cudatoolkit=10.1
 ```
 {: .stable-cuml-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuml=0.13 python=3.7 cudatoolkit=10.1
+    -c defaults cuml=0.14 python=3.7 cudatoolkit=10.1
 ```
 {: .stable-cuml-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cugraph=0.13 python=3.6 cudatoolkit=10.1
+    -c defaults cugraph=0.14 python=3.6 cudatoolkit=10.1
 ```
 {: .stable-cugraph-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cugraph=0.13 python=3.7 cudatoolkit=10.1
+    -c defaults cugraph=0.14 python=3.7 cudatoolkit=10.1
 ```
 {: .stable-cugraph-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cusignal=0.13 python=3.6 cudatoolkit=10.1
+    -c defaults cusignal=0.14 python=3.6 cudatoolkit=10.1
 ```
 {: .stable-cusignal-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cusignal=0.13 python=3.7 cudatoolkit=10.1
+    -c defaults cusignal=0.14 python=3.7 cudatoolkit=10.1
 ```
 {: .stable-cusignal-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.13 python=3.6 cudatoolkit=10.1
+    -c defaults cuspatial=0.14 python=3.6 cudatoolkit=10.1
 ```
 {: .stable-cuspatial-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.13 python=3.7 cudatoolkit=10.1
+    -c defaults cuspatial=0.14 python=3.7 cudatoolkit=10.1
 ```
 {: .stable-cuspatial-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.13 python=3.6 cudatoolkit=10.1
+    -c defaults cuxfilter=0.14 python=3.6 cudatoolkit=10.1
 ```
 {: .stable-cuxfilter-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.13 python=3.7 cudatoolkit=10.1
+    -c defaults cuxfilter=0.14 python=3.7 cudatoolkit=10.1
 ```
 {: .stable-cuxfilter-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults clx=0.13 python=3.6 cudatoolkit=10.1
+    -c defaults clx=0.14 python=3.6 cudatoolkit=10.1
 ```
 {: .stable-clx-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults clx=0.13 python=3.7 cudatoolkit=10.1
+    -c defaults clx=0.14 python=3.7 cudatoolkit=10.1
 ```
 {: .stable-clx-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults rapids=0.13 python=3.6 cudatoolkit=10.1
+    -c defaults rapids=0.14 python=3.6 cudatoolkit=10.1
 ```
 {: .stable-all-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults rapids=0.13 python=3.7 cudatoolkit=10.1
+    -c defaults rapids=0.14 python=3.7 cudatoolkit=10.1
 ```
 {: .stable-all-conda-py37-cuda101 .hidden }
 <!--
@@ -789,113 +789,113 @@ conda install -c rapidsai -c nvidia -c conda-forge \
 -->
 <!-- dev - ubuntu 16.04 -->
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-ubuntu16.04-py3.6
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-ubuntu16.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-ubuntu16.04-py3.6
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-ubuntu16.04-py3.6
 ```
 {: .nightly-all-dev-ubuntu1604-py36-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-ubuntu16.04-py3.7
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-ubuntu16.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-ubuntu16.04-py3.7
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-ubuntu16.04-py3.7
 ```
 {: .nightly-all-dev-ubuntu1604-py37-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-ubuntu16.04-py3.6
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-ubuntu16.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-ubuntu16.04-py3.6
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-ubuntu16.04-py3.6
 ```
 {: .nightly-all-dev-ubuntu1604-py36-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-ubuntu16.04-py3.7
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-ubuntu16.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-ubuntu16.04-py3.7
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-ubuntu16.04-py3.7
 ```
 {: .nightly-all-dev-ubuntu1604-py37-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-ubuntu16.04-py3.6
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-ubuntu16.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-ubuntu16.04-py3.6
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-ubuntu16.04-py3.6
 ```
 {: .nightly-all-dev-ubuntu1604-py36-cuda101 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-ubuntu16.04-py3.7
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-ubuntu16.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-ubuntu16.04-py3.7
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-ubuntu16.04-py3.7
 ```
 {: .nightly-all-dev-ubuntu1604-py37-cuda101 .hidden }
 <!-- dev - ubuntu 18.04 -->
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-ubuntu18.04-py3.6
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-ubuntu18.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-ubuntu18.04-py3.6
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-ubuntu18.04-py3.6
 ```
 {: .nightly-all-dev-ubuntu1804-py36-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-ubuntu18.04-py3.7
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-ubuntu18.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-ubuntu18.04-py3.7
 ```
 {: .nightly-all-dev-ubuntu1804-py37-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-ubuntu18.04-py3.6
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-ubuntu18.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-ubuntu18.04-py3.6
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-ubuntu18.04-py3.6
 ```
 {: .nightly-all-dev-ubuntu1804-py36-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-ubuntu18.04-py3.7
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-ubuntu18.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-ubuntu18.04-py3.7
 ```
 {: .nightly-all-dev-ubuntu1804-py37-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-ubuntu18.04-py3.6
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-ubuntu18.04-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-ubuntu18.04-py3.6
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-ubuntu18.04-py3.6
 ```
 {: .nightly-all-dev-ubuntu1804-py36-cuda101 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-ubuntu18.04-py3.7
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-ubuntu18.04-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-ubuntu18.04-py3.7
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-ubuntu18.04-py3.7
 ```
 {: .nightly-all-dev-ubuntu1804-py37-cuda101 .hidden }
 <!-- dev - centos 7 -->
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-centos7-py3.6
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-centos7-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-centos7-py3.6
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-centos7-py3.6
 ```
 {: .nightly-all-dev-centos7-py36-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-centos7-py3.7
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-centos7-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.2-devel-centos7-py3.7
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.2-devel-centos7-py3.7
 ```
 {: .nightly-all-dev-centos7-py37-cuda102 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-centos7-py3.6
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-centos7-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-centos7-py3.6
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-centos7-py3.6
 ```
 {: .nightly-all-dev-centos7-py36-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-centos7-py3.7
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-centos7-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.0-devel-centos7-py3.7
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.0-devel-centos7-py3.7
 ```
 {: .nightly-all-dev-centos7-py37-cuda100 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-centos7-py3.6
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-centos7-py3.6
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-centos7-py3.6
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-centos7-py3.6
 ```
 {: .nightly-all-dev-centos7-py36-cuda101 .hidden }
 ```bash
-docker pull rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-centos7-py3.7
+docker pull rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-centos7-py3.7
 docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
-    rapidsai/rapidsai-dev-nightly:0.14-cuda10.1-devel-centos7-py3.7
+    rapidsai/rapidsai-dev-nightly:0.15-cuda10.1-devel-centos7-py3.7
 ```
 {: .nightly-all-dev-centos7-py37-cuda101 .hidden }
 <!-- docker - ubuntu 16.04 -->
@@ -1031,279 +1031,279 @@ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
 <!-- conda cuda102 -->
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cudf=0.14 python=3.6 cudatoolkit=10.2
+    -c defaults cudf=0.15 python=3.6 cudatoolkit=10.2
 ```
 {: .nightly-cudf-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cudf=0.14 python=3.7 cudatoolkit=10.2
+    -c defaults cudf=0.15 python=3.7 cudatoolkit=10.2
 ```
 {: .nightly-cudf-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuml=0.14 python=3.6 cudatoolkit=10.2
+    -c defaults cuml=0.15 python=3.6 cudatoolkit=10.2
 ```
 {: .nightly-cuml-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuml=0.14 python=3.7 cudatoolkit=10.2
+    -c defaults cuml=0.15 python=3.7 cudatoolkit=10.2
 ```
 {: .nightly-cuml-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cugraph=0.14 python=3.6 cudatoolkit=10.2
+    -c defaults cugraph=0.15 python=3.6 cudatoolkit=10.2
 ```
 {: .nightly-cugraph-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cugraph=0.14 python=3.7 cudatoolkit=10.2
+    -c defaults cugraph=0.15 python=3.7 cudatoolkit=10.2
 ```
 {: .nightly-cugraph-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cusignal=0.14 python=3.6 cudatoolkit=10.2
+    -c defaults cusignal=0.15 python=3.6 cudatoolkit=10.2
 ```
 {: .nightly-cusignal-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cusignal=0.14 python=3.7 cudatoolkit=10.2
+    -c defaults cusignal=0.15 python=3.7 cudatoolkit=10.2
 ```
 {: .nightly-cusignal-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.14 python=3.6 cudatoolkit=10.2
+    -c defaults cuspatial=0.15 python=3.6 cudatoolkit=10.2
 ```
 {: .nightly-cuspatial-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.14 python=3.7 cudatoolkit=10.2
+    -c defaults cuspatial=0.15 python=3.7 cudatoolkit=10.2
 ```
 {: .nightly-cuspatial-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.14 python=3.6 cudatoolkit=10.2
+    -c defaults cuxfilter=0.15 python=3.6 cudatoolkit=10.2
 ```
 {: .nightly-cuxfilter-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.14 python=3.7 cudatoolkit=10.2
+    -c defaults cuxfilter=0.15 python=3.7 cudatoolkit=10.2
 ```
 {: .nightly-cuxfilter-conda-py37-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults rapids=0.14 python=3.6 cudatoolkit=10.2
+    -c defaults rapids=0.15 python=3.6 cudatoolkit=10.2
 ```
 {: .nightly-all-conda-py36-cuda102 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults rapids=0.14 python=3.7 cudatoolkit=10.2
+    -c defaults rapids=0.15 python=3.7 cudatoolkit=10.2
 ```
 {: .nightly-all-conda-py37-cuda102 .hidden }
 
 <!-- conda cuda100 -->
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cudf=0.14 python=3.6 cudatoolkit=10.0
+    -c defaults cudf=0.15 python=3.6 cudatoolkit=10.0
 ```
 {: .nightly-cudf-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cudf=0.14 python=3.7 cudatoolkit=10.0
+    -c defaults cudf=0.15 python=3.7 cudatoolkit=10.0
 ```
 {: .nightly-cudf-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuml=0.14 python=3.6 cudatoolkit=10.0
+    -c defaults cuml=0.15 python=3.6 cudatoolkit=10.0
 ```
 {: .nightly-cuml-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuml=0.14 python=3.7 cudatoolkit=10.0
+    -c defaults cuml=0.15 python=3.7 cudatoolkit=10.0
 ```
 {: .nightly-cuml-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cugraph=0.14 python=3.6 cudatoolkit=10.0
+    -c defaults cugraph=0.15 python=3.6 cudatoolkit=10.0
 ```
 {: .nightly-cugraph-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cugraph=0.14 python=3.7 cudatoolkit=10.0
+    -c defaults cugraph=0.15 python=3.7 cudatoolkit=10.0
 ```
 {: .nightly-cugraph-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cusignal=0.14 python=3.6 cudatoolkit=10.0
+    -c defaults cusignal=0.15 python=3.6 cudatoolkit=10.0
 ```
 {: .nightly-cusignal-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cusignal=0.14 python=3.7 cudatoolkit=10.0
+    -c defaults cusignal=0.15 python=3.7 cudatoolkit=10.0
 ```
 {: .nightly-cusignal-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.14 python=3.6 cudatoolkit=10.0
+    -c defaults cuspatial=0.15 python=3.6 cudatoolkit=10.0
 ```
 {: .nightly-cuspatial-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.14 python=3.7 cudatoolkit=10.0
+    -c defaults cuspatial=0.15 python=3.7 cudatoolkit=10.0
 ```
 {: .nightly-cuspatial-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.14 python=3.6 cudatoolkit=10.0
+    -c defaults cuxfilter=0.15 python=3.6 cudatoolkit=10.0
 ```
 {: .nightly-cuxfilter-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.14 python=3.7 cudatoolkit=10.0
+    -c defaults cuxfilter=0.15 python=3.7 cudatoolkit=10.0
 ```
 {: .nightly-cuxfilter-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults clx=0.14 python=3.6 cudatoolkit=10.0
+    -c defaults clx=0.15 python=3.6 cudatoolkit=10.0
 ```
 {: .nightly-clx-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults clx=0.14 python=3.7 cudatoolkit=10.0
+    -c defaults clx=0.15 python=3.7 cudatoolkit=10.0
 ```
 {: .nightly-clx-conda-py37-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults rapids=0.14 python=3.6
+    -c defaults rapids=0.15 python=3.6
 ```
 {: .nightly-all-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults rapids=0.14 python=3.7
+    -c defaults rapids=0.15 python=3.7
 ```
 {: .nightly-all-conda-py37-cuda100 .hidden }
 
 <!-- conda cuda101 -->
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cudf=0.14 python=3.6 cudatoolkit=10.1
+    -c defaults cudf=0.15 python=3.6 cudatoolkit=10.1
 ```
 {: .nightly-cudf-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cudf=0.14 python=3.7 cudatoolkit=10.1
+    -c defaults cudf=0.15 python=3.7 cudatoolkit=10.1
 ```
 {: .nightly-cudf-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuml=0.14 python=3.6 cudatoolkit=10.1
+    -c defaults cuml=0.15 python=3.6 cudatoolkit=10.1
 ```
 {: .nightly-cuml-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuml=0.14 python=3.7 cudatoolkit=10.1
+    -c defaults cuml=0.15 python=3.7 cudatoolkit=10.1
 ```
 {: .nightly-cuml-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cugraph=0.14 python=3.6 cudatoolkit=10.1
+    -c defaults cugraph=0.15 python=3.6 cudatoolkit=10.1
 ```
 {: .nightly-cugraph-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cugraph=0.14 python=3.7 cudatoolkit=10.1
+    -c defaults cugraph=0.15 python=3.7 cudatoolkit=10.1
 ```
 {: .nightly-cugraph-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cusignal=0.14 python=3.6 cudatoolkit=10.0
+    -c defaults cusignal=0.15 python=3.6 cudatoolkit=10.0
 ```
 {: .nightly-cusignal-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cusignal=0.14 python=3.7 cudatoolkit=10.0
+    -c defaults cusignal=0.15 python=3.7 cudatoolkit=10.0
 ```
 {: .nightly-cusignal-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.14 python=3.6 cudatoolkit=10.1
+    -c defaults cuspatial=0.15 python=3.6 cudatoolkit=10.1
 ```
 {: .nightly-cuspatial-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuspatial=0.14 python=3.7 cudatoolkit=10.1
+    -c defaults cuspatial=0.15 python=3.7 cudatoolkit=10.1
 ```
 {: .nightly-cuspatial-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.14 python=3.6 cudatoolkit=10.1
+    -c defaults cuxfilter=0.15 python=3.6 cudatoolkit=10.1
 ```
 {: .nightly-cuxfilter-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults cuxfilter=0.14 python=3.7 cudatoolkit=10.1
+    -c defaults cuxfilter=0.15 python=3.7 cudatoolkit=10.1
 ```
 {: .nightly-cuxfilter-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults clx=0.14 python=3.6 cudatoolkit=10.1
+    -c defaults clx=0.15 python=3.6 cudatoolkit=10.1
 ```
 {: .nightly-clx-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults clx=0.14 python=3.7 cudatoolkit=10.1
+    -c defaults clx=0.15 python=3.7 cudatoolkit=10.1
 ```
 {: .nightly-clx-conda-py37-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults rapids=0.14 python=3.6 cudatoolkit=10.1
+    -c defaults rapids=0.15 python=3.6 cudatoolkit=10.1
 ```
 {: .nightly-all-conda-py36-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults rapids=0.14 python=3.7 cudatoolkit=10.1
+    -c defaults rapids=0.15 python=3.7 cudatoolkit=10.1
 ```
 {: .nightly-all-conda-py37-cuda101 .hidden }
 <!--

--- a/dask.md
+++ b/dask.md
@@ -125,7 +125,7 @@ The RAPIDS **[cuDF library](https://github.com/rapidsai/cudf){: target="_blank"}
 ## <i class="fas fa-bezier-curve"></i> XGBoost Integration
 XGBoost, the popular open source machine learning library for gradient boosting, now includes integrated support for Dask. Users can partition data across nodes using Dask’s standard data structures, build a DMatrix on each GPU using `xgboost.dask.create_worker_dmatrix`, and then launch training through `xgboost.dask.run`. See the **[XGBoost dask documentation](https://ml.dask.org/xgboost.html){: target="_blank"}** or the **[Dask+XGBoost GPU example code](https://github.com/dmlc/xgboost/tree/master/demo/dask){: target="_blank"}** for more details.
 
-New users should check out our **[XGBoost page](https://rapids.ai/xgboost.html){: target="_blank"}** and the **[10 Minutes to Dask-XGBoost guide](https://rapidsai.github.io/projects/cudf/en/{{ site.data.releases.stable-docs }}/dask-xgb-10min.html){: target="_blank"}** to get started quickly.
+New users should check out our **[XGBoost page](https://rapids.ai/xgboost.html){: target="_blank"}** and the **[10 Minutes to Dask-XGBoost guide](https://docs.rapids.ai/api/cudf/stable/dask-xgb-10min.html){: target="_blank"}** to get started quickly.
 {% endcapture %}
 
 {% include section-halfs.html

--- a/index.md
+++ b/index.md
@@ -80,12 +80,12 @@ Jump right into a GPU powered RAPIDS notebook with **[Colabratory](https://colab
 ## <i class="far fa-bookmark"></i> 10 Minutes to cuDF
 {: .section-subtitle-top-1}
 
-Modeled after 10 Minutes to Pandas, this is a short introduction to cuDF that is geared mainly for new users. <br> **[Go to guide <i class="fa fa-angle-double-right" aria-hidden="true"></i>](https://rapidsai.github.io/projects/cudf/en/{{ site.data.releases.stable-docs }}/10min.html){: target="_blank"}**
+Modeled after 10 Minutes to Pandas, this is a short introduction to cuDF that is geared mainly for new users. <br> **[Go to guide <i class="fa fa-angle-double-right" aria-hidden="true"></i>](https://docs.rapids.ai/api/cudf/stable/10min.html){: target="_blank"}**
 
 ## <i class="far fa-bookmark"></i> 10 Minutes to Dask-XGBoost
 {: .section-subtitle-top-1}
 
-A short introduction to XGBoost with a distributed CUDA DataFrame via Dask-cuDF. <br> **[Go to guide <i class="fas fa-angle-double-right"></i>](https://rapidsai.github.io/projects/cudf/en/{{ site.data.releases.stable-docs }}/dask-xgb-10min.html){: target="_blank"}**
+A short introduction to XGBoost with a distributed CUDA DataFrame via Dask-cuDF. <br> **[Go to guide <i class="fas fa-angle-double-right"></i>](https://docs.rapids.ai/api/cudf/stable/dask-xgb-10min.html){: target="_blank"}**
 
 
 ## <i class="far fa-bookmark"></i> Example Notebooks


### PR DESCRIPTION
This PR updates the site for the 0.14 release. It includes the following changes:

- Updates `_data/releases.yml` with the latest version numbers & dates
- Update `_includes/options.html` versions for the `RAPIDS RELEASE SELECTOR`
- Removes `<legacy/stable/nightly>-docs` variables from `_data/releases.yml` since they pertain to the deprecated `rapidsai/projects` repo
- Updates old links that point to `rapidsai/projects`