### PR TITLE
[skip ci] Update master references for main branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ Once your changes are ready in your fork, create a [new pull request](https://gi
 
 1. Submit proposed changes as a PR to this repo from the contributor's fork
 2. Review PR providing feedback and request any necessary changes
-3. Approve PR merging into `master` of this repo
+3. Approve PR merging into `main` of this repo
 4. Verify the staging site https://rapidsai.github.io/rapidsai-staging/ to ensure there are no errors or issues after merge
 5. Approve promotion to PROD 
-   - This is done through a CI process that merges `master` of this repo into the PROD repo and updates the `_config.yml` to match PROD
+   - This is done through a CI process that merges `main` of this repo into the PROD repo and updates the `_config.yml` to match PROD
 6. Verify PROD site updated

--- a/dask.md
+++ b/dask.md
@@ -118,7 +118,7 @@ Dask can distribute data and computation over multiple GPUs, either in the same 
 
 {% capture gpus_df %}
 ## <i class="fas fa-layer-group"></i> Dataframe and ETL Integration
-The RAPIDS **[cuDF library](https://github.com/rapidsai/cudf){: target="_blank"}** provides a GPU-backed dataframe class that replicates the popular pandas API. It includes extremely high-performance functions to load CSV, JSON, ORC, Parquet and other file formats directly into GPU memory, eliminating one of the key bottlenecks in many data processing tasks. cuDF includes a variety of other functions supporting GPU-accelerated ETL, such as data subsetting, transformations, one-hot encoding, and more. The RAPIDS team maintains a **[dask-cudf library](https://github.com/rapidsai/cudf/tree/master/python/dask_cudf){: target="_blank"}** that includes helper methods to use Dask and cuDF.
+The RAPIDS **[cuDF library](https://github.com/rapidsai/cudf){: target="_blank"}** provides a GPU-backed dataframe class that replicates the popular pandas API. It includes extremely high-performance functions to load CSV, JSON, ORC, Parquet and other file formats directly into GPU memory, eliminating one of the key bottlenecks in many data processing tasks. cuDF includes a variety of other functions supporting GPU-accelerated ETL, such as data subsetting, transformations, one-hot encoding, and more. The RAPIDS team maintains a **[dask-cudf library](https://github.com/rapidsai/cudf/tree/main/python/dask_cudf){: target="_blank"}** that includes helper methods to use Dask and cuDF.
 {% endcapture %}
 
 {% capture gpus_xgb %}
@@ -137,7 +137,7 @@ New users should check out our **[XGBoost page](https://rapids.ai/xgboost.html){
 
 {% capture gpus_ml%}
 ## <i class="fas fa-sliders-h"></i> Integration With Other ML Algorithms 
-For other machine learning work on GPU, the **[cuML library](https://github.com/rapidsai/cuml/tree/master/python/cuml/dask){: target="_blank"}** provides a access to the RAPIDS cuML package with Dask. RAPIDS cuML implements popular machine learning algorithms, including clustering, dimensionality reduction, and regression approaches, with high performance GPU-based implementations, offering speedups of up to **100x** over CPU-based approaches. cuML replicates the scikit-learn API, so it integrates well with projects like Dask that include scikit-learn support. Currently, dask-cuml supports distributed clustering and regression algorithms, with new algorithms are being added over time.
+For other machine learning work on GPU, the **[cuML library](https://github.com/rapidsai/cuml/tree/main/python/cuml/dask){: target="_blank"}** provides a access to the RAPIDS cuML package with Dask. RAPIDS cuML implements popular machine learning algorithms, including clustering, dimensionality reduction, and regression approaches, with high performance GPU-based implementations, offering speedups of up to **100x** over CPU-based approaches. cuML replicates the scikit-learn API, so it integrates well with projects like Dask that include scikit-learn support. Currently, dask-cuml supports distributed clustering and regression algorithms, with new algorithms are being added over time.
 {% endcapture %}
 
 {% capture gpus_nb %}
@@ -145,10 +145,10 @@ For other machine learning work on GPU, the **[cuML library](https://github.com/
 The RAPIDS Notebooks Extended repository includes several examples with end-to-end examples using Dask for distributed, GPU-accelerated computation. Here’s a few from the collection to get started with. 
 
 
-<i class="fas fa-caret-right"></i> The Introductino to Dask shows how to get started with Dask using basic Python primitives like integers and strings. **[Go to notebook <i class="fas fa-angle-double-right"></i>](https://github.com/rapidsai/notebooks-contrib/blob/master/getting_started_notebooks/basics/Getting_Started_with_Dask.ipynb){: target="_blank"}**
+<i class="fas fa-caret-right"></i> The Introductino to Dask shows how to get started with Dask using basic Python primitives like integers and strings. **[Go to notebook <i class="fas fa-angle-double-right"></i>](https://github.com/rapidsai/notebooks-contrib/blob/main/getting_started_notebooks/basics/Getting_Started_with_Dask.ipynb){: target="_blank"}**
 {: .no-tb-margins }
 
-<i class="fas fa-caret-right"></i> Introduction to XGBoost with RAPIDS shows the acceleration one can gain by using GPUs with XGBoost in RAPIDS. **[Go to notebook <i class="fas fa-angle-double-right"></i>](https://github.com/rapidsai/notebooks/blob/master/xgboost/XGBoost_Demo.ipynb){: target="_blank"}**
+<i class="fas fa-caret-right"></i> Introduction to XGBoost with RAPIDS shows the acceleration one can gain by using GPUs with XGBoost in RAPIDS. **[Go to notebook <i class="fas fa-angle-double-right"></i>](https://github.com/rapidsai/notebooks/blob/main/xgboost/XGBoost_Demo.ipynb){: target="_blank"}**
 {: .no-tb-margins }
 
 <i class="fas fa-caret-right"></i> The Linear Regression with Dask+cuML shows a simple example of how to get started with distributed machine learning. **[Go to notebook <i class="fas fa-angle-double-right"></i>](https://github.com/rapidsai/notebooks-contrib/blob/a236188a08ba7ec77a55ec48e5a5a1d6e81c9895/tutorials/examples/linear_regression_dask_cuml.ipynb){: target="_blank"}**
@@ -303,4 +303,3 @@ The Dask interactive dashboard gives real-time feedback during computations, poi
 {% include cta-footer-dask.html 
    background="background-darkpurple" 
 %}
-

--- a/index.md
+++ b/index.md
@@ -226,7 +226,7 @@ Whether you are new to RAPIDS, looking to help, or are part of the team, learn a
 {% capture lib1_left %}
 ## <i class="fad fa-terminal"></i> cuDF <span class="api-tag">API</span>
 
-**[GitHub](https://github.com/rapidsai/cudf){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/cudf/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cudf/blob/master/CHANGELOG.md){: target="_blank"}**
+**[GitHub](https://github.com/rapidsai/cudf){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/cudf/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md){: target="_blank"}**
 {: .no-tb-margins }
 
 cuDF is a Python GPU DataFrame library (built on the **[Apache Arrow](http://arrow.apache.org/){: target="_blank"}** columnar memory format) for loading, joining, aggregating, filtering, and otherwise manipulating data all in a **[pandas-like](https://pandas.pydata.org/){: target="_blank"}** API familiar to data scientists.
@@ -235,7 +235,7 @@ cuDF is a Python GPU DataFrame library (built on the **[Apache Arrow](http://arr
 {% capture lib1_right %}
 ## <i class="fad fa-terminal"></i> libcudf <span class="lib-tag">LIB</span>
 
-**[GitHub](https://github.com/rapidsai/cudf){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/libcudf/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cudf/blob/master/CHANGELOG.md){: target="_blank"}**
+**[GitHub](https://github.com/rapidsai/cudf){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/libcudf/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md){: target="_blank"}**
 {: .no-tb-margins }
 
 libcudf is a C/C++ CUDA library for implementing standard dataframe operations. It is part of the cuDF repository. 
@@ -244,7 +244,7 @@ libcudf is a C/C++ CUDA library for implementing standard dataframe operations. 
 {% capture lib2_left %}
 ## <i class="fad fa-terminal"></i> cuML <span class="api-tag">API</span>
 
-**[GitHub](https://github.com/rapidsai/cuml){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/cuml/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cuml/blob/master/CHANGELOG.md){: target="_blank"}**
+**[GitHub](https://github.com/rapidsai/cuml){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/cuml/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cuml/blob/main/CHANGELOG.md){: target="_blank"}**
 {: .no-tb-margins }
 
 cuML is a suite of libraries that implement machine learning algorithms and mathematical primitives functions that are compatible with other RAPIDS projects, all in a **[scikit-learn-like](https://scikit-learn.org/stable/index.html){: target="_blank"}** API familiar to data scientists.
@@ -254,7 +254,7 @@ cuML is a suite of libraries that implement machine learning algorithms and math
 {% capture lib2_right %}
 ## <i class="fad fa-terminal"></i> cuGraph <span class="api-tag">API</span>
 
-**[GitHub](https://github.com/rapidsai/cugraph){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/cugraph/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cugraph/blob/master/CHANGELOG.md){: target="_blank"}**
+**[GitHub](https://github.com/rapidsai/cugraph){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/cugraph/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cugraph/blob/main/CHANGELOG.md){: target="_blank"}**
 {: .no-tb-margins }
 
 cuGraph is a GPU accelerated graph analytics library, with functionality like **[NetworkX](https://networkx.github.io/){: target="_blank"}**, which is seamlessly integrated into the RAPIDS data science platform.
@@ -263,7 +263,7 @@ cuGraph is a GPU accelerated graph analytics library, with functionality like **
 {% capture lib3_left %} 
 ## <i class="fad fa-terminal"></i> cuSignal <span class="api-tag">API</span>
 
-**[GitHub](https://github.com/rapidsai/cusignal){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/cusignal/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cusignal/blob/master/CHANGELOG.md){: target="_blank"}**
+**[GitHub](https://github.com/rapidsai/cusignal){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/cusignal/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cusignal/blob/main/CHANGELOG.md){: target="_blank"}**
 {: .no-tb-margins }
 
 cuSignal is a GPU accelerated signal processing library built around a **[SciPy Signal-like](https://docs.scipy.org/doc/scipy/reference/signal.html){: target="_blank"}** API, CuPy, and custom Numba and CuPy CUDA kernels. cuSignal is written exclusively in Python and demonstrates GPU speeds without a C++ software layer.
@@ -272,7 +272,7 @@ cuSignal is a GPU accelerated signal processing library built around a **[SciPy 
 {% capture lib3_right %}
 ## <i class="fad fa-terminal"></i> cuSpatial <span class="api-tag">API</span>
 
-**[GitHub](https://github.com/rapidsai/cuspatial){: target="_blank"}** **/** **[Docs](https://github.com/rapidsai/cuspatial){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cuspatial/blob/master/CHANGELOG.md){: target="_blank"}**
+**[GitHub](https://github.com/rapidsai/cuspatial){: target="_blank"}** **/** **[Docs](https://github.com/rapidsai/cuspatial){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cuspatial/blob/main/CHANGELOG.md){: target="_blank"}**
 {: .no-tb-margins }
 
 cuSpatial is an efficient C++ library accelerated on GPUs with Python bindings to enable use by the data science community. cuSpatial provides significant GPU-acceleration to common spatial and spatiotemporal operations such as point-in-polygon tests, distances between trajectories, and trajectory clustering when compared to CPU-based implementations. 
@@ -281,7 +281,7 @@ cuSpatial is an efficient C++ library accelerated on GPUs with Python bindings t
 {% capture lib4_left %} 
 ## <i class="fad fa-terminal"></i> cuxfilter <span class="api-tag">API</span>
 
-**[GitHub](https://github.com/rapidsai/cuxfilter){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/cuxfilter/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cuxfilter/blob/master/CHANGELOG.md){: target="_blank"}**
+**[GitHub](https://github.com/rapidsai/cuxfilter){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/cuxfilter/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cuxfilter/blob/main/CHANGELOG.md){: target="_blank"}**
 {: .no-tb-margins }
 
 cuxfilter is a framework to connect web visualizations to GPU accelerated crossfiltering. Inspired by the javascript version of the **[original](https://github.com/crossfilter/crossfilter){: target="_blank"}**, it enables interactive and super fast multi-dimensional filtering of 100 million+ row tabular datasets via **[cuDF](https://github.com/rapidsai/cudf){: target="_blank"}**.
@@ -290,7 +290,7 @@ cuxfilter is a framework to connect web visualizations to GPU accelerated crossf
 {% capture lib4_right %} 
 ## <i class="fad fa-terminal"></i> CLX <span class="api-tag">API</span>
 
-**[GitHub](https://github.com/rapidsai/clx){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/clx/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/clx/blob/master/CHANGELOG.md){: target="_blank"}**
+**[GitHub](https://github.com/rapidsai/clx){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/clx/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/clx/blob/main/CHANGELOG.md){: target="_blank"}**
 {: .no-tb-margins }
 
 Cyber Log Accelerators (CLX), also pronounced "clicks", provides a collection of RAPIDS examples for security analysts, data scientists, and engineers to quickly get started applying RAPIDS and GPU acceleration to real-world cybersecurity use cases.
@@ -298,7 +298,7 @@ Cyber Log Accelerators (CLX), also pronounced "clicks", provides a collection of
 {% capture lib5_left %}
 ## <i class="fad fa-terminal"></i> nvStrings <span class="api-tag">API</span>
 
-**[GitHub](https://github.com/rapidsai/cudf){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/nvstrings/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cudf/blob/master/CHANGELOG.md){: target="_blank"}**
+**[GitHub](https://github.com/rapidsai/cudf){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/nvstrings/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/cudf/blob/main/CHANGELOG.md){: target="_blank"}**
 {: .no-tb-margins }
 
 nvStrings, the Python bindings for **[cuStrings](https://github.com/rapidsai/cudf){: target="_blank"}**, provides a pandas-like API that will be familiar to data engineers & data scientists, so they can use it to easily accelerate their workflows without going into the details of CUDA programming.
@@ -307,7 +307,7 @@ nvStrings, the Python bindings for **[cuStrings](https://github.com/rapidsai/cud
 {% capture lib5_right %}
 ## <i class="fad fa-terminal"></i> RMM <span class="lib-tag">LIB</span>
 
-**[GitHub](https://github.com/rapidsai/rmm){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/rmm/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/rmm/blob/master/CHANGELOG.md){: target="_blank"}**
+**[GitHub](https://github.com/rapidsai/rmm){: target="_blank"}** **/** **[Docs](https://docs.rapids.ai/api/rmm/stable/){: target="_blank"}** **/** **[Change Log](https://github.com/rapidsai/rmm/blob/main/CHANGELOG.md){: target="_blank"}**
 {: .no-tb-margins }
 
 RAPIDS Memory Manager (RMM) is a central place for all device memory allocations in cuDF (C++ and Python) and other RAPIDS libraries. In addition, it is a replacement allocator for CUDA Device Memory (and CUDA Managed Memory) and a pool allocator to make CUDA device memory allocation / deallocation faster and asynchronous.

--- a/plotly.md
+++ b/plotly.md
@@ -67,7 +67,7 @@ Read how straightforward it is to integrate RAPIDS libraries like cuDF with a Pl
 {% capture rpd_mid %}
 ## <i class="fal fa-analytics"></i> Example Apps
 
-Explore the code for the **[Plotly Dash + RAPIDS 2010 Census Visualization](https://github.com/rapidsai/plotly-dash-rapids-census-demo/tree/master){: target="_blank"}** and its **[Covid-19 Branch](https://github.com/rapidsai/plotly-dash-rapids-census-demo/tree/covid-19){: target="_blank"}** on GitHub. 
+Explore the code for the **[Plotly Dash + RAPIDS 2010 Census Visualization](https://github.com/rapidsai/plotly-dash-rapids-census-demo/tree/main){: target="_blank"}** and its **[Covid-19 Branch](https://github.com/rapidsai/plotly-dash-rapids-census-demo/tree/covid-19){: target="_blank"}** on GitHub. 
 
 {% endcapture %}
 
@@ -244,5 +244,3 @@ Dash Cytoscape is a graph visualization component for creating easily customizab
 {% include cta-footer-plotly.html 
    background="background-darkpurple" 
 %}
-
-

--- a/start.md
+++ b/start.md
@@ -113,12 +113,12 @@ RAPIDS is available as conda packages, docker images, and from source builds. Us
 ## <i class="fas fa-laptop-code"></i> Conda Install
 You can get a minimal conda installation with **[Miniconda](https://conda.io/miniconda.html){: target="_blank"}** or get the full installation with **[Anaconda](https://www.anaconda.com/download){: target="_blank"}**.
 
-For instructions on how to build a development conda environment, see the **[cuDF README](https://github.com/rapidsai/cudf/blob/master/README.md#conda){: target="_blank"}** for more information. Also refer to the **[cuML README](https://github.com/rapidsai/cuml/blob/master/README.md#conda){: target="_blank"}** for conda install instructions for cuML.
+For instructions on how to build a development conda environment, see the **[cuDF README](https://github.com/rapidsai/cudf/blob/main/README.md#conda){: target="_blank"}** for more information. Also refer to the **[cuML README](https://github.com/rapidsai/cuml/blob/main/README.md#conda){: target="_blank"}** for conda install instructions for cuML.
 
 ## <i class="far fa-file-code"></i> Build From Source
 {: .section-subtitle-top-2}
 
-Checkout the **[cuDF README](https://github.com/rapidsai/cudf/tree/master#development-setup){: target="_blank"}**, **[cuML README](https://github.com/rapidsai/cuml/tree/master#installing-from-source){: target="_blank"}**, or **[cuGraph README](https://github.com/rapidsai/cugraph/tree/master#build-from-source-and-contributing){: target="_blank"}** for from-source build instructions.
+Checkout the **[cuDF README](https://github.com/rapidsai/cudf/tree/main#development-setup){: target="_blank"}**, **[cuML README](https://github.com/rapidsai/cuml/tree/main#installing-from-source){: target="_blank"}**, or **[cuGraph README](https://github.com/rapidsai/cugraph/tree/main#build-from-source-and-contributing){: target="_blank"}** for from-source build instructions.
 
 ## <i class="fas fa-laptop-code"></i> Where is Pip?
 {: .section-subtitle-top-2}
@@ -183,5 +183,3 @@ name="TRY RAPIDS NOW"
 button="LAUNCH IN COLAB"
 link="https://colab.research.google.com/drive/1rY7Ln6rEE1pOlfSHCYOVaqt8OvDO35J0#forceEdit=true&offline=true&sandboxMode=true"
 %}
-
-


### PR DESCRIPTION
This PR changes any 'master' references to 'main' in markdown files throughout the repo as part of the new 'master' to 'main' branch migration.