### PR TITLE
FIX Add symlink for rapids_logo.png

### DIFF
--- a/assets/images/rapids_logo.png
+++ b/assets/images/rapids_logo.png
@@ -1,0 +1,1 @@
+RAPIDS-logo-white.png


### PR DESCRIPTION
This is used by docs across the repo and was not in the staging site. With the switchover the image has been missing from a lot of README files. This will fix that without having to update all of the README files.

An example in the [docker](https://www.github.com/rapidsai/docker) repo:
![Screen Shot 2020-07-29 at 11 56 15](https://user-images.githubusercontent.com/1915404/88823034-a01e6b80-d192-11ea-9278-2673450fc476.png)
