### PR TITLE
FIX Specify CTK for default conda install

### DIFF
--- a/_includes/selector-commands-legacy.html
+++ b/_includes/selector-commands-legacy.html
@@ -414,13 +414,13 @@ conda install -c rapidsai -c nvidia -c conda-forge \
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults rapids=0.14 python=3.6
+    -c defaults rapids=0.14 python=3.6 cudatoolkit=10.0
 ```
 {: .legacy-all-conda-py36-cuda100 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults rapids=0.14 python=3.7
+    -c defaults rapids=0.14 python=3.7 cudatoolkit=10.0
 ```
 {: .legacy-all-conda-py37-cuda100 .hidden }
 

--- a/_includes/selector-commands-nightly.html
+++ b/_includes/selector-commands-nightly.html
@@ -511,13 +511,13 @@ conda install -c rapidsai-nightly -c nvidia -c conda-forge \
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults rapids=0.16 python=3.8
+    -c defaults rapids=0.16 python=3.8 cudatoolkit=10.1
 ```
 {: .nightly-all-conda-py38-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai-nightly -c nvidia -c conda-forge \
-    -c defaults rapids=0.16 python=3.7
+    -c defaults rapids=0.16 python=3.7 cudatoolkit=10.1
 ```
 {: .nightly-all-conda-py37-cuda101 .hidden }
 <!--

--- a/_includes/selector-commands-stable.html
+++ b/_includes/selector-commands-stable.html
@@ -511,13 +511,13 @@ conda install -c rapidsai -c nvidia -c conda-forge \
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults rapids=0.15 python=3.8
+    -c defaults rapids=0.15 python=3.8 cudatoolkit=10.1
 ```
 {: .stable-all-conda-py38-cuda101 .hidden }
 
 ```bash
 conda install -c rapidsai -c nvidia -c conda-forge \
-    -c defaults rapids=0.15 python=3.7
+    -c defaults rapids=0.15 python=3.7 cudatoolkit=10.1
 ```
 {: .stable-all-conda-py37-cuda101 .hidden }
 <!--


### PR DESCRIPTION
This corrects a situation where without the CTK, CUDA 11.0 is installed when it should be CUDA 10.1