### PR TITLE
Remove cuxfilter 0.15 release notices & JS

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -258,14 +258,8 @@ function processClick(options, click, category) {
             selections['python'] = 'py37';
             $("#py36").removeClass("active");
         }
-        // Disable cuxfilter until released
-        if (selections['pkg'] == 'cuxfilter') {
-            selections['pkg'] = 'all';
-            $("#cuxfilter").removeClass("active");
-        }
         $("#cuda100").addClass("disabled");
         $("#py36").addClass("disabled");
-        $("#cuxfilter").addClass("disabled");
     }
 
     // Handle legacy specific exlcusions
@@ -285,7 +279,6 @@ function processClick(options, click, category) {
         $("#py38").addClass("disabled");
         $("#cuda110").addClass("disabled");
         $("#all").addClass("disabled");
-        $("#cuxfilter").removeClass("disabled");
     }
 
     $("#" + selections['method']).addClass("active");


### PR DESCRIPTION
This PR removes the `cuxfilter` notice from the RAPIDS selector and also removes the JS logic that prevents `cuxfilter` from being selected for `stable`/`nightly` versions.