### PR TITLE
FIX Re-add symlink for logo used in `README.md`s

### DIFF
--- a/assets/images/rapids_logo.png
+++ b/assets/images/rapids_logo.png
@@ -1,0 +1,1 @@
+RAPIDS-logo-white.png


### PR DESCRIPTION
Broken in #135, re-adds the symlink from #123 that fixes broken `README.md` logos. See #123 for more info

FYI @exactlyallan - this symlink needs to stay in place