### PR TITLE
[REVIEW] Update cloud instructions

### DIFF
--- a/cloud.md
+++ b/cloud.md
@@ -732,6 +732,9 @@ RAPIDS can be deployed on Google Cloud as a single instance:
 
 **[Jump to Top <i class="fad fa-chevron-double-up"></i>](#deploy)**
 
+
+{% endcapture %}
+
 {% capture gc_dask %}
 ## <i class="fab fa-google"></i> Google Cluster via Dask (Dataproc)
 


### PR DESCRIPTION
Updates:
- Docker image
- Removes instructions for using RAPIDS on GCP instance with Jupyterlab