### PR TITLE
Append `dask-sql` to RAPIDS selector

### DIFF
--- a/_includes/selector-commands-nightly.html
+++ b/_includes/selector-commands-nightly.html
@@ -422,48 +422,48 @@ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
 <!-- conda all 11.0 -->
 ```bash
 conda create -n rapids-{{site.data.releases.nightly-version}} -c rapidsai-nightly -c nvidia -c conda-forge \
-    rapids={{site.data.releases.nightly-version}} python=3.7 cudatoolkit=11.0
+    rapids={{site.data.releases.nightly-version}} python=3.7 cudatoolkit=11.0 dask-sql
 ```
 {: .nightly-all-conda-py37-cuda110 .hidden }
 ```bash
 conda create -n rapids-{{site.data.releases.nightly-version}} -c rapidsai-nightly -c nvidia -c conda-forge \
-    rapids={{site.data.releases.nightly-version}} python=3.8 cudatoolkit=11.0
+    rapids={{site.data.releases.nightly-version}} python=3.8 cudatoolkit=11.0 dask-sql
 ```
 {: .nightly-all-conda-py38-cuda110 .hidden }
 
 <!-- conda all 11.2 -->
 ```bash
 conda create -n rapids-{{site.data.releases.nightly-version}} -c rapidsai-nightly -c nvidia -c conda-forge \
-    rapids={{site.data.releases.nightly-version}} python=3.7 cudatoolkit=11.2
+    rapids={{site.data.releases.nightly-version}} python=3.7 cudatoolkit=11.2 dask-sql
 ```
 {: .nightly-all-conda-py37-cuda112 .hidden }
 ```bash
 conda create -n rapids-{{site.data.releases.nightly-version}} -c rapidsai-nightly -c nvidia -c conda-forge \
-    rapids={{site.data.releases.nightly-version}} python=3.8 cudatoolkit=11.2
+    rapids={{site.data.releases.nightly-version}} python=3.8 cudatoolkit=11.2 dask-sql
 ```
 {: .nightly-all-conda-py38-cuda112 .hidden }
 
 <!-- conda all 11.4 -->
 ```bash
 conda create -n rapids-{{site.data.releases.nightly-version}} -c rapidsai-nightly -c nvidia -c conda-forge \
-    rapids={{site.data.releases.nightly-version}} python=3.7 cudatoolkit=11.4
+    rapids={{site.data.releases.nightly-version}} python=3.7 cudatoolkit=11.4 dask-sql
 ```
 {: .nightly-all-conda-py37-cuda114 .hidden }
 ```bash
 conda create -n rapids-{{site.data.releases.nightly-version}} -c rapidsai-nightly -c nvidia -c conda-forge \
-    rapids={{site.data.releases.nightly-version}} python=3.8 cudatoolkit=11.4
+    rapids={{site.data.releases.nightly-version}} python=3.8 cudatoolkit=11.4 dask-sql
 ```
 {: .nightly-all-conda-py38-cuda114 .hidden }
 
 <!-- conda all 11.5 -->
 ```bash
 conda create -n rapids-{{site.data.releases.nightly-version}} -c rapidsai-nightly -c nvidia -c conda-forge \
-    rapids={{site.data.releases.nightly-version}} python=3.7 cudatoolkit=11.5
+    rapids={{site.data.releases.nightly-version}} python=3.7 cudatoolkit=11.5 dask-sql
 ```
 {: .nightly-all-conda-py37-cuda115 .hidden }
 ```bash
 conda create -n rapids-{{site.data.releases.nightly-version}} -c rapidsai-nightly -c nvidia -c conda-forge \
-    rapids={{site.data.releases.nightly-version}} python=3.8 cudatoolkit=11.5
+    rapids={{site.data.releases.nightly-version}} python=3.8 cudatoolkit=11.5 dask-sql
 ```
 {: .nightly-all-conda-py38-cuda115 .hidden }
 

--- a/_includes/selector-commands-stable.html
+++ b/_includes/selector-commands-stable.html
@@ -422,48 +422,48 @@ docker run --gpus all --rm -it -p 8888:8888 -p 8787:8787 -p 8786:8786 \
 <!-- conda all 11.0 -->
 ```bash
 conda create -n rapids-{{site.data.releases.stable-version}} -c rapidsai -c nvidia -c conda-forge \
-    rapids={{site.data.releases.stable-version}} python=3.7 cudatoolkit=11.0
+    rapids={{site.data.releases.stable-version}} python=3.7 cudatoolkit=11.0 dask-sql
 ```
 {: .stable-all-conda-py37-cuda110 .hidden }
 ```bash
 conda create -n rapids-{{site.data.releases.stable-version}} -c rapidsai -c nvidia -c conda-forge \
-    rapids={{site.data.releases.stable-version}} python=3.8 cudatoolkit=11.0
+    rapids={{site.data.releases.stable-version}} python=3.8 cudatoolkit=11.0 dask-sql
 ```
 {: .stable-all-conda-py38-cuda110 .hidden }
 
 <!-- conda all 11.2 -->
 ```bash
 conda create -n rapids-{{site.data.releases.stable-version}} -c rapidsai -c nvidia -c conda-forge \
-    rapids={{site.data.releases.stable-version}} python=3.7 cudatoolkit=11.2
+    rapids={{site.data.releases.stable-version}} python=3.7 cudatoolkit=11.2 dask-sql
 ```
 {: .stable-all-conda-py37-cuda112 .hidden }
 ```bash
 conda create -n rapids-{{site.data.releases.stable-version}} -c rapidsai -c nvidia -c conda-forge \
-    rapids={{site.data.releases.stable-version}} python=3.8 cudatoolkit=11.2
+    rapids={{site.data.releases.stable-version}} python=3.8 cudatoolkit=11.2 dask-sql
 ```
 {: .stable-all-conda-py38-cuda112 .hidden }
 
 <!-- conda all 11.4 -->
 ```bash
 conda create -n rapids-{{site.data.releases.stable-version}} -c rapidsai -c nvidia -c conda-forge \
-    rapids={{site.data.releases.stable-version}} python=3.7 cudatoolkit=11.4
+    rapids={{site.data.releases.stable-version}} python=3.7 cudatoolkit=11.4 dask-sql
 ```
 {: .stable-all-conda-py37-cuda114 .hidden }
 ```bash
 conda create -n rapids-{{site.data.releases.stable-version}} -c rapidsai -c nvidia -c conda-forge \
-    rapids={{site.data.releases.stable-version}} python=3.8 cudatoolkit=11.4
+    rapids={{site.data.releases.stable-version}} python=3.8 cudatoolkit=11.4 dask-sql
 ```
 {: .stable-all-conda-py38-cuda114 .hidden }
 
 <!-- conda all 11.5 -->
 ```bash
 conda create -n rapids-{{site.data.releases.stable-version}} -c rapidsai -c nvidia -c conda-forge \
-    rapids={{site.data.releases.stable-version}} python=3.7 cudatoolkit=11.5
+    rapids={{site.data.releases.stable-version}} python=3.7 cudatoolkit=11.5 dask-sql
 ```
 {: .stable-all-conda-py37-cuda115 .hidden }
 ```bash
 conda create -n rapids-{{site.data.releases.stable-version}} -c rapidsai -c nvidia -c conda-forge \
-    rapids={{site.data.releases.stable-version}} python=3.8 cudatoolkit=11.5
+    rapids={{site.data.releases.stable-version}} python=3.8 cudatoolkit=11.5 dask-sql
 ```
 {: .stable-all-conda-py38-cuda115 .hidden }
 

--- a/generate_selector.py
+++ b/generate_selector.py
@@ -88,7 +88,7 @@ def generate_conda_all(config, meta_package):
             channel = "rapidsai" + ("-nightly" if config["name"] == "nightly" else "")
             cmd = "```bash\n\
 conda create -n rapids-"+rapids_ver+" -c "+channel+" -c nvidia -c conda-forge \\\n\
-    "+meta_package+"="+rapids_ver+" python="+py_ver+" cudatoolkit="+cuda_ver+"\n\
+    "+meta_package+"="+rapids_ver+" python="+py_ver+" cudatoolkit="+cuda_ver+" dask-sql"+"\n\
 ```\n\
 {: ."+tag_name+"-all-conda-py"+tag_py+"-cuda"+tag_cuda+" .hidden }\n"
             config["cmds"].append(cmd)


### PR DESCRIPTION
This PR appends the `dask-sql` package to the RAPIDS selector whenever the _All Packages_ option is selected for `conda` installs.