### PR TITLE
Add channel priority disclaimer

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -95,7 +95,7 @@
                 <div class="note" x-show="getNoteHtml()">
                     <div class="option-label"></div>
                     <div class="option-blank">
-                        <span class="option-note" x-html="getNoteHtml()"></span>
+                        <div class="option-note-container" x-html="getNoteHtml()"></div>
                     </div>
                 </div>
             </div>
@@ -312,7 +312,7 @@
                 if (option === "development") return "Development Image";
                 return option;
             },
-            getDockerNote() {
+            getDockerNotes() {
                 var core_pkgs = this.rapids_meta_pkgs;
 
                 if (this.active_img_type === "standard") {
@@ -322,40 +322,41 @@
                     core_pkgs = [...core_pkgs, "clx"];
                 }
                 var pkgs_html = core_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
-                return this.note_prefix + " The selected image contains the following packages:<br>" + pkgs_html
+                return [this.note_prefix + " The selected image contains the following packages:<br>" + pkgs_html];
             },
-            getCondaNote() {
+            getCondaNotes() {
                 var notes = [];
+                notes = [...notes, "RAPIDS currently doesn't support <code>channel_priority: strict</code>; use <code>channel_priority: flexible</code> instead"];
                 if (this.active_packages.length === 1 && this.active_packages[0] === "Standard") {
                     var pkgs_html = this.rapids_meta_pkgs.map(pkg => "<code>" + pkg + "</code>").join(", ");
-                    notes = [...notes, "The <code>Standard</code> selection contains the following packages:<br>" + pkgs_html]
+                    notes = [...notes, "The <code>Standard</code> selection contains the following packages:<br>" + pkgs_html];
                 }
 
                 if (this.active_additional_packages.length) {
-                    notes = [...notes, "Third-party packages are not tested."]
+                    notes = [...notes, "Third-party packages are not tested."];
                 }
 
-                return notes.map(note => this.note_prefix + " " + note).join("<br>");
+                return notes.map(note => this.note_prefix + " " + note);
             },
-            getArmNote() {
-                return this.note_prefix + " ARM support does not currently include Jetson products.";
+            getArmNotes() {
+                return [this.note_prefix + " ARM support does not currently include Jetson products."];
             },
             getNoteHtml() {
                 var notes = [];
 
                 if (this.active_arch === "arm") {
-                    notes.push(this.getArmNote());
+                    notes.push(...this.getArmNotes());
                 }
 
                 if (this.active_method === "Docker") {
-                    notes.push(this.getDockerNote());
+                    notes.push(...this.getDockerNotes());
                 }
 
                 if (this.active_method === "Conda") {
-                    notes.push(this.getCondaNote());
+                    notes.push(...this.getCondaNotes());
                 }
 
-                return notes.join("<br>");
+                return notes.map(note => `<div class="option-note">${note}</div>`).join("");
             },
             getCmdHtml() {
                 if (this.active_method === "Docker")

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1072,6 +1072,10 @@ a.blue-btn,
     color: #3c3c3c;
 }
 
+.option-note {
+    margin-bottom: 10px;
+}
+
 /* blog posts */
 .blog-container h1, .posts-container h1 {
     margin-bottom: 0.1em;


### PR DESCRIPTION
This PR adds a channel priority disclaimer which indicates that `channel_priority: strict` is not supported with `conda` installs.

Closes #218.

Additionally, this makes some minor changes to the HTML structure of notes and adds some margin to the bottom of each note since it seems that we're adding quite a few now.