### PR TITLE
Add redirect for rapids.ai/slack-invite.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,9 @@ collections:
     output: false
   posts:
     output: false
+  redirects:
+    output: true
+    permalink: /:path/
 
 defaults:
   - scope:

--- a/_redirects/slack-invite/index.html
+++ b/_redirects/slack-invite/index.html
@@ -1,0 +1,8 @@
+<html>
+
+<head>
+  <meta http-equiv="refresh" content="0; url={{ site.slack_invite }}">
+  <link rel="canonical" href="{{ site.slack_invite }}" />
+</head>
+
+</html>


### PR DESCRIPTION
This PR adds a redirect from https://rapids.ai/slack-invite to the Slack invitation URL defined as a site-wide variable in `_config.yml`. This makes a "tiny" style of link that will fit on a presentation slide for @JohnZed. 🚀