### PR TITLE
Fix slack invite redirect

### DIFF
--- a/_redirects/slack-invite.html
+++ b/_redirects/slack-invite.html
@@ -1,0 +1,11 @@
+---
+layout: none
+---
+<html>
+
+<head>
+  <meta http-equiv="refresh" content="0; url={{ site.slack_invite }}">
+  <link rel="canonical" href="{{ site.slack_invite }}" />
+</head>
+
+</html>

--- a/_redirects/slack-invite/index.html
+++ b/_redirects/slack-invite/index.html
@@ -1,8 +1,0 @@
-<html>
-
-<head>
-  <meta http-equiv="refresh" content="0; url={{ site.slack_invite }}">
-  <link rel="canonical" href="{{ site.slack_invite }}" />
-</head>
-
-</html>


### PR DESCRIPTION
This PR fixes the `/slack-invite` redirect. The file needed some frontmatter in order to be interpreted as a template (so that variables could be parsed) rather than a static file.

Also, `layout: none` was used so that the default Jekyll layout isn't used to render the `/slack-invite` page. This is important because the redirect is technically a client side redirect, so without `layout: none`, it would show the default layout's `header` and `footer` momentarily before the actual redirect occurred which isn't a great user experience.