### PR TITLE
Re-add NGC changes

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -467,6 +467,9 @@
                 if (method !== "Conda") {
                     this.active_additional_packages = [];
                 }
+                if (method === "Docker") {
+                    this.active_release = "Stable"
+                }
                 this.active_method = method;
             },
             imgOSClickHandler(e, version) {


### PR DESCRIPTION
This PR re-adds the NGC changes from #226 that were reverted in #231. This PR should only be merged after the NGC permission issues are resolved. Marking it as a draft until then.