### PR TITLE
[REVIEW] update selector to not include NGC when selecting arm

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -429,6 +429,7 @@
             },
             disableUnsupportedImgLoc(loc) {
                 var isDisabled = false;
+				if (this.active_arch === "arm" && loc !== "Dockerhub") isDisabled = true;
                 return isDisabled;
             },
             isDisabled(e) {
@@ -448,6 +449,7 @@
                 if (arch === "arm") this.active_img_type = "core";
                 if (arch === "arm" && this.active_os_ver === "CentOS 7") this.active_os_ver = "Ubuntu 20.04";
                 if (arch === "arm" && this.active_cuda_ver === "11.0") this.active_cuda_ver = "11.2";
+				if (arch === "arm" && this.active_method === "Docker") this.active_img_loc = "Dockerhub";
                 this.active_arch = arch;
             },
             cudaClickHandler(e, version) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -472,6 +472,8 @@
                 if (method === "Docker") {
                     this.active_release = "Stable"
                 }
+				if (method === "Docker" && this.active_arch === "arm") this.active_img_loc = "Dockerhub";
+
                 this.active_method = method;
             },
             imgOSClickHandler(e, version) {
@@ -482,7 +484,7 @@
                 if (this.isDisabled(e.target)) return;
 
                 if (loc === "NGC" && this.active_release !== "Stable") this.active_release = "Stable";
-
+				
                 this.active_img_loc = loc;
             },
             imgOptionClickHandler(e, option) {


### PR DESCRIPTION
Selector incorrectly guides users to get ARM containers for NGC.  Those containers are not available there at this time.