### PR TITLE
Swap nvidia and conda-forge channel order.

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -221,7 +221,7 @@
                 var cuda_version = this.active_cuda_ver;
                 var pkgs = this.active_packages;
                 var py_cuda_pkgs = [this.highlightPkgOrImg("python") + "=" + python_version, this.highlightPkgOrImg("cudatoolkit") + "=" + cuda_version].join(" ");
-                var conda_channels = [rapids_channel, "nvidia", "conda-forge"]
+                var conda_channels = [rapids_channel, "conda-forge", "nvidia"]
                     .map(ch => this.highlightFlag("-c") + " " + ch + " ")
                     .join("");
                 var indentation = "    ";


### PR DESCRIPTION
This is needed for the 22.10[.01?] hotfix. Users should prioritize the channel `conda-forge` over `nvidia` so that `cuda-python` is installed from the `conda-forge` channel.

cc: @shwina

⚠️ **This should not be merged until the rest of the hotfix changes are released.**