### PR TITLE
Remove Google Groups links and email.

### DIFF
--- a/_includes/cta-footer-help.html
+++ b/_includes/cta-footer-help.html
@@ -2,10 +2,6 @@
     <div class="container-padding">
         <div class="footer-help-section">
             <div class="footer-help-box">
-                <i class="fas fa-users fa-3x icon"></i>
-                <a href="https://groups.google.com/forum/#!forum/rapidsai" target="_blank" class="primary-btn">Google Groups</a>
-            </div>
-            <div class="footer-help-box">
                 <i class="fab fa-docker fa-3x icon"></i>
                 <a href="https://hub.docker.com/r/rapidsai/rapidsai" target="_blank" class="primary-btn">Docker Hub</a>
             </div>

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -26,7 +26,6 @@
             </li>
             <li>
                 <br>
-                <a class="footer-icon" href="mailto:RAPIDSai@googlegroups.com"><i class="fas fa-envelope fa-2x dark-purple-font"></i></a>
                 <a class="footer-icon" href="https://twitter.com/rapidsai" target="_blank"><i class="fab fa-twitter fa-2x dark-purple-font"></i></a>
                 <a class="footer-icon" href="{{ site.slack_invite }}" target="_blank"><i class="fab fa-slack fa-2x dark-purple-font"></i></a>
                 <a class="footer-icon" href="https://stackoverflow.com/tags/rapids" target="_blank"><i class="fab fa-stack-overflow fa-2x dark-purple-font"></i></a>

--- a/community.md
+++ b/community.md
@@ -145,7 +145,7 @@ Anyone can join our community and contribute to to RAPIDS in a five step onboard
 
 > **<i class="fas fa-download text-purple"></i> 1. Install** RAPIDS using **[Docker or Conda](https://rapids.ai/start.html#get-rapids){: target="_blank"}**. Or try RAPIDSAI with **[SageMaker Studio Lab](smsl.html){: target="_blank"}** (free account required).
 
-> **<i class="far fa-comments text-purple"></i>  2. Join** our community conversations on **[Twitter](https://twitter.com/rapidsai){: target="_blank"}**, **[Google Groups](https://groups.google.com/forum/#!forum/rapidsai){: target="_blank"}**, and **[Slack]({{ site.slack_invite }}){: target="_blank"}**.
+> **<i class="far fa-comments text-purple"></i>  2. Join** our community conversations on **[Twitter](https://twitter.com/rapidsai){: target="_blank"}** and **[Slack]({{ site.slack_invite }}){: target="_blank"}**.
 
 > **<i class="fas fa-search text-purple"></i> 3. Explore** our **[docs](https://docs.rapids.ai/){: target="_blank"}**, **[walk through videos](https://www.youtube.com/channel/UCsoi4wfweA3I5FsPgyQnnqw?view_as=subscriber){: target="_blank"}**, **[blog posts](https://medium.com/rapids-ai){: target="_blank"}**, **[tutorial notebooks](https://github.com/rapidsai/notebooks-contrib#getting-started-notebooks){: target="_blank"}**, and our **[examples workflows](https://github.com/rapidsai/notebooks-contrib#intermediate-notebooks){: target="_blank"}**.
 
@@ -191,5 +191,3 @@ Anyone can join our community and contribute to to RAPIDS in a five step onboard
 {% include cta-footer-help.html
    background="background-darkpurple"
 %}
-
-


### PR DESCRIPTION
The Google Group for rapidsai is shutting down October 31, 2022. https://groups.google.com/g/rapidsai/c/kxQufCW1NeU

This PR removes references to that Google Group from the website.

cc: @robocopnixon