### PR TITLE
Remove file extensions from nav links

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,18 +1,18 @@
 - nav: HOME
   name: index
-  link: /index.html
+  link: /
 
 - nav: ABOUT
   name: about
-  link: /about.html
+  link: /about
 
 - nav: GET STARTED
   name: start
-  link: /start.html
+  link: /start
 
 - nav: COMMUNITY
   name: community
-  link: /community.html
+  link: /community
 
 - nav: BLOG
   name: blog


### PR DESCRIPTION
This PR removes the file extensions from our navigation links to produce more user-friendly URLs.

e.g. https://rapids.ai/community instead of https://rapids.ai/community.html