### PR TITLE
Update selector to disable development containers on NGC.

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -324,7 +324,7 @@
             },
             getImgOptionText(option) {
                 if (option === "notebooks") return "Include Jupyter Notebooks";
-                if (option === "development") return "Development Image";
+                if (option === "development") return "Development Image (only on Docker Hub)";
                 return option;
             },
             getImgLoc(loc) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -425,6 +425,8 @@
             },
             disableUnsupportedImgOption(option) {
                 var isDisabled = false;
+                var isNGC = this.active_img_loc === "NGC"
+                if (isNGC && option === "development") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedImgLoc(loc) {
@@ -480,6 +482,11 @@
                 if (this.isDisabled(e.target)) return;
 
                 if (loc === "NGC" && this.active_release !== "Stable") this.active_release = "Stable";
+
+                // Disable development option when clicking NGC
+                if (loc === "NGC" && this.active_img_options.includes("development")) {
+                    this.active_img_options = this.active_img_options.filter(el => el !== "development")
+                }
 
                 this.active_img_loc = loc;
             },

--- a/merlin.md
+++ b/merlin.md
@@ -80,7 +80,7 @@ Try on Kaggle with:
 NVTabular and HugeCTR both provide a collection of examples based on a variety of recommender system datasets that are publicly available. Checkout the **[NVTabular notebooks](https://github.com/NVIDIA/NVTabular/tree/main/examples){: target="_blank"}** and **[HugeCTR notebooks](https://github.com/NVIDIA/HugeCTR/tree/master/notebooks){: target="_blank"}**.
 
 ## <i class="fab fa-docker"></i> Pull Our Docker Container
-Merlin published docker containers with pre-installed versions of the latest release on **[NVIDIA's NGC repository](https://ngc.nvidia.com/catalog/containers?orderBy=modifiedDESC&pageNumber=0&query=%20label%3A%22Merlin%22&quickFilter=containers&filters=){: target="_blank"}**. Pull the container and try out Merlin yourself.
+Merlin published docker containers with pre-installed versions of the latest release on **[NVIDIA's NGC repository](https://catalog.ngc.nvidia.com/containers?filters=&orderBy=dateModifiedDESC&query=label:%22Merlin%22&page=0&pageSize=25){: target="_blank"}**. Pull the container and try out Merlin yourself.
 
 
 ## <i class="far fa-file-code"></i> See The Latest Docs

--- a/start.md
+++ b/start.md
@@ -286,7 +286,7 @@ Pip installation of RAPIDS is back!  You can **[try our experimental pip package
 # Step 3: Install RAPIDS
 {: .section-title-full}
 
-RAPIDS is available in conda packages, docker images, and from source builds. Use the tool below to select your preferred method, packages, and environment to install RAPIDS. Certain combinations may not be possible and are dimmed automatically. Be sure you've met the **[system requirements](#requirements)** above and see the **[Next Steps](#next-steps)** below.
+RAPIDS is available in conda packages, docker images, and from source builds. Use the tool below to select your preferred method, packages, and environment to install RAPIDS. Certain combinations may not be possible and are dimmed automatically. Be sure you've met the **[System Requirements](#requirements)** above and see the **[Next Steps](#next-steps)** below.
 {: .padding-bottom-3em }
 
 ## **Release Selector**

--- a/start.md
+++ b/start.md
@@ -63,7 +63,7 @@ In four steps, easily install RAPIDS on a local system or cloud instance with a 
 ## **[<i class="fad fa-chevron-double-down"></i> Step 2: Install Environment](#environment)**
 
 - Choose to use Conda, Docker, or **[try pip (Experimental)](pip.html)**.
-- Choose to Build from source 
+- Choose to Build from source
 
 
 {% endcapture %}
@@ -286,7 +286,7 @@ Pip installation of RAPIDS is back!  You can **[try our experimental pip package
 # Step 3: Install RAPIDS
 {: .section-title-full}
 
-RAPIDS is available in conda packages, docker images, and from source builds. Use the tool below to select your preferred method, packages, and environment to install RAPIDS. Certain combinations may not be possible and are dimmed automatically. Be sure you've met the required **[Prerequisites above](#requirements)** and see the **[Next Steps](#next-steps)** below.
+RAPIDS is available in conda packages, docker images, and from source builds. Use the tool below to select your preferred method, packages, and environment to install RAPIDS. Certain combinations may not be possible and are dimmed automatically. Be sure you've met the **[system requirements](#requirements)** above and see the **[Next Steps](#next-steps)** below.
 {: .padding-bottom-3em }
 
 ## **Release Selector**


### PR DESCRIPTION
We will no longer be uploading development containers to NGC, only Docker Hub. This PR updates the selector logic to disable development containers when selecting NGC as the image location.