### PR TITLE
Update existing redirects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,8 +4,6 @@ postsurl: "https://rapidsai.github.io/site-data/posts.json"
 slack_invite: "https://join.slack.com/t/rapids-goai/shared_invite/zt-trnsul8g-Sblci8dk6dIoEeGpoFcFOQ"
 exclude: ['_drafts', 'README.md', '.gitignore', 'CNAME']
 include: ['_redirects']
-plugins:
-  - jekyll-redirect-from
 
 collections:
   authors:

--- a/_drafts/templates/new-default-layout.md
+++ b/_drafts/templates/new-default-layout.md
@@ -6,8 +6,6 @@ button_text: "Button text under tagline"
 button_link: "https://page.to/somewhere"
 layout: default
 permalink: # unused - only used to override where page is displayed
-redirect_from: # unused - only used when forcing a redirect from an old page
-# NOTE: anything marked as 'unused' can be ommitted from the front-matter
 ---
 
 # Hello RAPIDS

--- a/_drafts/templates/new-short-layout.md
+++ b/_drafts/templates/new-short-layout.md
@@ -6,8 +6,6 @@ button_text: #unused - not available for short layout
 button_link: #unused - not available for short layout
 layout: short
 permalink: #unused - only used to override where page is displayed
-redirect_from: #unused - only used when forcing a redirect from an old page
-# NOTE: anything marked as 'unused' can be ommitted from the front-matter
 ---
 
 # Hello RAPIDS

--- a/_redirects
+++ b/_redirects
@@ -6,3 +6,4 @@ layout: none
 /cloud              https://docs.rapids.ai/deployment/stable/cloud/
 /smsl               https://studiolab.sagemaker.aws/import/github/rapidsai-community/rapids-smsl/blob/main/rapids-smsl.ipynb
 /slack-invite       {{ site.slack_invite }}
+/documentation.html /start

--- a/start.md
+++ b/start.md
@@ -5,7 +5,6 @@ tagline: "Get RAPIDS Now"
 button_text: "SELECT RELEASE"
 button_link: "#get-rapids"
 layout: default
-redirect_from: "/documentation.html" # redirect from old page to ensure existing links still work
 ---
 
 # Getting Started


### PR DESCRIPTION
This PR is a continuation of #275.

Since we've recently switched our site hosting to Netlify, and therefore have access to server side redirects via the `_redirects` file, we can remove the `jekyll-redirect-from` plugin (which does client side redirects) and replace any instances where it was used with proper server side redirects.

This PR makes those changes.