### PR TITLE
Redirect cloud.html to deployment docs

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -4,6 +4,7 @@ layout: none
 
 # Redirects from what the browser requests to what we serve
 /cloud              https://docs.rapids.ai/deployment/stable/cloud/
+/cloud.html         https://docs.rapids.ai/deployment/stable/cloud/
 /smsl               https://studiolab.sagemaker.aws/import/github/rapidsai-community/rapids-smsl/blob/main/rapids-smsl.ipynb
 /slack-invite       {{ site.slack_invite }}
 /documentation.html /start


### PR DESCRIPTION
I found a reference in an issue to `/cloud.html`. That page just 404s, and I think it probably always has and the link was a typo. But still thought it might be good to redirect that too just in case `/cloud.html` is used elsewhere.