### PR TITLE
Platform support updates for 23.02.

### DIFF
--- a/_data/releases.yml
+++ b/_data/releases.yml
@@ -1,9 +1,9 @@
 # Versions for site
 #
 # NOTE: Must use "" to prevent losing data like 0.10 -> 0.1
-legacy-version: "22.10"
-legacy-date: "OCT 2022"
-stable-version: "22.12"
-stable-date: "DEC 2022"
-nightly-version: "23.02"
-nightly-date: "FEB 2023"
+legacy-version: "22.12"
+legacy-date: "DEC 2022"
+stable-version: "23.02"
+stable-date: "FEB 2023"
+nightly-version: "23.04"
+nightly-date: "APR 2023"

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -414,7 +414,6 @@
             disableUnsupportedImgOS(os) {
                 var isDisabled = false;
                 if (this.active_arch === "arm" && os === "CentOS 7") isDisabled = true;
-                if (this.active_release === "Nightly" && os === "CentOS 8") isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedImgType(type) {
@@ -437,7 +436,6 @@
             },
             releaseClickHandler(e, release) {
                 if (this.isDisabled(e.target)) return;
-                if (release === "Nightly" && this.active_os_ver === "CentOS 8") this.active_os_ver = "CentOS 7";
                 this.active_release = release;
             },
             imgTypeClickHandler(e, type) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -139,7 +139,7 @@
 
             // all possible values
             python_vers: ["3.8", "3.10"],
-            cuda_vers: ["11.2", "11.4", "11.8"],
+            cuda_vers: ["11.2", "11.4", "11.5", "11.8"],
             os_vers: ["Ubuntu 20.04", "Ubuntu 22.04", "CentOS 7", "Rocky Linux 8"],
             methods: ["Conda", "Docker", "Source"],
             releases: ["Stable", "Nightly"],

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -125,9 +125,9 @@
     document.addEventListener('alpine:init', () => {
         Alpine.data('rapids_selector', () => ({
             // default values
-            active_python_ver: "3.9",
-            active_cuda_ver: "11.5",
-            active_os_ver: "Ubuntu 20.04",
+            active_python_ver: "3.10",
+            active_cuda_ver: "11.8",
+            active_os_ver: "Ubuntu 22.04",
             active_method: "Conda",
             active_release: "Stable",
             active_arch: "amd",
@@ -138,9 +138,9 @@
             active_additional_packages: [],
 
             // all possible values
-            python_vers: ["3.8", "3.9"],
-            cuda_vers: ["11.2", "11.4", "11.5"],
-            os_vers: ["Ubuntu 18.04", "Ubuntu 20.04", "CentOS 7", "Rocky Linux 8"],
+            python_vers: ["3.8", "3.10"],
+            cuda_vers: ["11.2", "11.4", "11.8"],
+            os_vers: ["Ubuntu 20.04", "Ubuntu 22.04", "CentOS 7", "Rocky Linux 8"],
             methods: ["Conda", "Docker", "Source"],
             releases: ["Stable", "Nightly"],
             arches: ["amd", "arm"],
@@ -404,7 +404,6 @@
                 if (this.active_img_options.includes("development") && cuda_version !== this.getNewestCudaVer()) {
                     isDisabled = true;
                 }
-                if (this.active_arch === "arm" && cuda_version === "11.0") isDisabled = true;
                 if (this.active_additional_packages.includes("TensorFlow") && cuda_version !== "11.2") isDisabled = true;
                 return isDisabled;
             },
@@ -448,8 +447,7 @@
             archClickHandler(e, arch) {
                 if (this.isDisabled(e.target)) return;
                 if (arch === "arm") this.active_img_type = "core";
-                if (arch === "arm" && this.active_os_ver === "CentOS 7") this.active_os_ver = "Ubuntu 20.04";
-                if (arch === "arm" && this.active_cuda_ver === "11.0") this.active_cuda_ver = "11.2";
+                if (arch === "arm" && this.active_os_ver === "CentOS 7") this.active_os_ver = "Ubuntu 22.04";
                 this.active_arch = arch;
             },
             cudaClickHandler(e, version) {

--- a/pip.md
+++ b/pip.md
@@ -40,7 +40,7 @@ RAPIDS users can once again install RAPIDS via pip!  This is an **experimental r
 
 > <i class="fas fa-desktop text-white"></i> **OS:** One of the following OS versions:
 
->> <i class="fa-brands fa-ubuntu text-white"></i> Ubuntu 18.04/20.04 or CentOS 7 / Rocky Linux 8 with <code>gcc/++</code> 9.0+
+>> <i class="fa-brands fa-ubuntu text-white"></i> Ubuntu 20.04/22.04 or CentOS 7 / Rocky Linux 8 with <code>gcc/++</code> 9.0+
 
 >> <i class="fas fa-desktop text-white"></i> Windows 11 using WSL2  **[See separate install guide <i class="fa fa-angle-double-right" aria-hidden="true"></i>](wsl2.html){: target="_blank"}**
 
@@ -50,9 +50,9 @@ RAPIDS users can once again install RAPIDS via pip!  This is an **experimental r
 
 > <i class="fas fa-microchip text-white"></i> **GPU:** Only GPUs with **[Compute capability](https://developer.nvidia.com/cuda-gpus){: target="_blank"}** 6.0 or higher (i.e. Pascal generation or newer) are supported.
 
-> <i class="fas fa-download text-white"></i> **CUDA >= 11.5**, with at least the v495.29.05 driver. To use CUDA 11.2, 11.3, or 11.4, please see Troubleshooting and Known Issues.
+> <i class="fas fa-download text-white"></i> **CUDA >= 11.8**, with at least the v520.61.05 driver. To use older versions of CUDA 11.x, please see Troubleshooting and Known Issues.
 
-> <i class="fab fa-python text-white"></i> **Python and pip version:** Python 3.8 or 3.9 using pip 20.3+ with **[PEP600 support](https://peps.python.org/pep-0600/){: target="_blank"}**.
+> <i class="fab fa-python text-white"></i> **Python and pip version:** Python 3.8 or 3.10 using pip 20.3+ with **[PEP600 support](https://peps.python.org/pep-0600/){: target="_blank"}**.
 
 ## <i class="far fa-comments text-white"></i> Connect
 
@@ -71,19 +71,19 @@ RAPIDS users can once again install RAPIDS via pip!  This is an **experimental r
 ## <i class="fad fa-terminal text-white"></i> Installation Commands
 
 
-	pip install cudf-cu11 dask-cudf-cu11 --extra-index-url=https://pypi.ngc.nvidia.com
-	pip install cuml-cu11 --extra-index-url=https://pypi.ngc.nvidia.com
-	pip install cugraph-cu11 --extra-index-url=https://pypi.ngc.nvidia.com
+    pip install cudf-cu11 dask-cudf-cu11 --extra-index-url=https://pypi.nvidia.com
+    pip install cuml-cu11 --extra-index-url=https://pypi.nvidia.com
+    pip install cugraph-cu11 --extra-index-url=https://pypi.nvidia.com
 
 > <i class="fas fa-info-circle text-white"></i> The RAPIDS pip packages are hosted on the NVIDIA NGC index today.
 
 > <i class="fas fa-info-circle text-white"></i> On ARM architecture (aarch64), cupy needs to be installed separately:
 
-	pip install cupy-cuda11x -f https://pip.cupy.dev/aarch64
+    pip install cupy-cuda11x -f https://pip.cupy.dev/aarch64
 
 ## <i class="fa-solid fa-screwdriver-wrench text-white"></i> Troubleshooting and Known Issues
 
-> <i class="fas fa-info-circle text-white"></i> When installing these packages with CUDA 11.2, 11.3, or 11.4, you may experience a "Failed to import CuPy" error. To resolve this error, please uninstall cupy-cuda115 and install cupy-cuda11x:
+> <i class="fas fa-info-circle text-white"></i> If you experience a "Failed to import CuPy" error, please uninstall any existing versions of cupy and install cupy-cuda11x:
 
     pip uninstall cupy-cuda115; pip install cupy-cuda11x
 
@@ -94,11 +94,11 @@ RAPIDS users can once again install RAPIDS via pip!  This is an **experimental r
 
 > Check the suggestions below for possible resolutions.
 
-> <i class="fas fa-chevron-circle-right text-white"></i> Your Python version must be 3.8 or 3.9.
+> <i class="fas fa-chevron-circle-right text-white"></i> Your Python version must be 3.8 or 3.10.
 
 > <i class="fas fa-chevron-circle-right text-white"></i> RAPIDS pip packages require a recent version of pip that **[supports PEP600](https://peps.python.org/pep-0600/){: target="_blank"}**.  Some users may need to update pip:
 
-	pip install -U pip
+    pip install -U pip
 
 > <i class="fas fa-chevron-circle-right text-white"></i> Infiniband is not supported yet in this release
 
@@ -106,8 +106,8 @@ RAPIDS users can once again install RAPIDS via pip!  This is an **experimental r
 
 > <i class="fas fa-chevron-circle-right text-white"></i> Dask / Jupyter / Tornado 6.2 dependency conflicts can occur. Install jupyter-client 7.3.4 if the error below occurs:
 
-      ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
-      jupyter-client 7.4.2 requires tornado>=6.2, but you have tornado 6.1 which is incompatible.
+    ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
+    jupyter-client 7.4.2 requires tornado>=6.2, but you have tornado 6.1 which is incompatible.
 
 
 {% endcapture %}

--- a/pip.md
+++ b/pip.md
@@ -83,7 +83,7 @@ RAPIDS users can once again install RAPIDS via pip!  This is an **experimental r
 
 ## <i class="fa-solid fa-screwdriver-wrench text-white"></i> Troubleshooting and Known Issues
 
-> <i class="fas fa-info-circle text-white"></i> If you experience a "Failed to import CuPy" error, please uninstall any existing versions of cupy and install cupy-cuda11x:
+> <i class="fas fa-info-circle text-white"></i> If you experience a "Failed to import CuPy" error, please uninstall any existing versions of cupy and install cupy-cuda11x. For example:
 
     pip uninstall cupy-cuda115; pip install cupy-cuda11x
 

--- a/start.md
+++ b/start.md
@@ -108,7 +108,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 <i class="fas fa-microchip text-purple"></i> **GPU:** NVIDIA Pascal™ or better with **[compute capability](https://developer.nvidia.com/cuda-gpus){: target="_blank"}** 6.0+
 
 <i class="fas fa-desktop text-purple"></i> **OS:** One of the following OS versions:
-> <i class="fa-brands fa-ubuntu text-purple"></i>Ubuntu 18.04/20.04 or CentOS 7 / Rocky Linux 8 with <code>gcc/++</code> 9.0+
+> <i class="fa-brands fa-ubuntu text-purple"></i>Ubuntu 20.04/22.04 or CentOS 7 / Rocky Linux 8 with <code>gcc/++</code> 9.0+
 {: .no-tb-margins }
 > <i class="fas fa-desktop text-purple"></i> Windows 11 using WSL2  **[See separate install guide <i class="fa fa-angle-double-right" aria-hidden="true"></i>](wsl2.html){: target="_blank"}**
 {: .no-tb-margins }
@@ -119,7 +119,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
 - <i class="fas fa-check-circle text-purple"></i> [CUDA 11.2](https://developer.nvidia.com/cuda-11.2.0-download-archive){: target="_blank"} with Driver 460.27.03 or newer
 - <i class="fas fa-check-circle text-purple"></i> [CUDA 11.4](https://developer.nvidia.com/cuda-11-4-0-download-archive){: target="_blank"} with Driver 470.42.01 or newer
-- <i class="fas fa-check-circle text-purple"></i> [CUDA 11.5](https://developer.nvidia.com/cuda-11-5-0-download-archive){: target="_blank"} with Driver 495.29.05 or newer
+- <i class="fas fa-check-circle text-purple"></i> [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 520.61.05 or newer
 - Note: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details.
 
 {% endcapture %}

--- a/start.md
+++ b/start.md
@@ -119,6 +119,7 @@ All provisioned systems need to be RAPIDS capable. Here's what is required:
 
 - <i class="fas fa-check-circle text-purple"></i> [CUDA 11.2](https://developer.nvidia.com/cuda-11.2.0-download-archive){: target="_blank"} with Driver 460.27.03 or newer
 - <i class="fas fa-check-circle text-purple"></i> [CUDA 11.4](https://developer.nvidia.com/cuda-11-4-0-download-archive){: target="_blank"} with Driver 470.42.01 or newer
+- <i class="fas fa-check-circle text-purple"></i> [CUDA 11.5](https://developer.nvidia.com/cuda-11-5-0-download-archive){: target="_blank"} with Driver 495.29.05 or newer
 - <i class="fas fa-check-circle text-purple"></i> [CUDA 11.8](https://developer.nvidia.com/cuda-11-8-0-download-archive){: target="_blank"} with Driver 520.61.05 or newer
 - Note: RAPIDS is tested with and officially supports the versions listed above. Newer CUDA and driver versions may also work with RAPIDS. See [CUDA compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/index.html) for details.
 

--- a/wsl2.md
+++ b/wsl2.md
@@ -41,7 +41,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 
 > <i class="fas fa-microchip text-white"></i> **GPU:** Only GPUs with [Compute Capability](https://developer.nvidia.com/cuda-gpus){: target="_blank"} 7.0 or higher are supported on RAPIDS in WSL 2. 16GB or more of GPU RAM is recommended.
 
-> <i class="fas fa-download text-white"></i> **WSL 2 Instance:** Ubuntu 20.04 instance for WSL 2.
+> <i class="fas fa-download text-white"></i> **WSL 2 Instance:** Ubuntu 20.04/22.04 instance for WSL 2.
 
 ## <i class="far fa-comments text-white"></i> Connect
 > Join our community conversations about RAPIDS on WSL 2 using **[Twitter](https://twitter.com/rapidsai){: target="_blank"}**, **[Slack]({{ site.slack_invite }}){: target="_blank"}**, or ask a question on **[StackOverflow](https://stackoverflow.com/tags/rapids){: target="_blank"}**.
@@ -89,7 +89,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 {% capture yd_left %}
 ## <i class="fas fa-laptop-code"></i> Conda <br>(Preferred Method)
 
-1. Install WSL 2 and the Ubuntu 20.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
+1. Install WSL 2 and the Ubuntu 20.04/22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Log in to the WSL 2 Linux instance.
 4. Install Conda in the WSL 2 Linux Instance using [our Conda instructions](https://rapids.ai/start.html#environment){: target="_blank"}.
@@ -105,7 +105,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 {% capture yd_mid %}
 ## <i class="fab fa-python text-purple"></i> pip
 
-1. Install WSL 2 and the Ubuntu 20.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
+1. Install WSL 2 and the Ubuntu 20.04/22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Log in to the WSL 2 Linux instance.
 4. Follow **[this guide to install the CUDA Toolkit without drivers](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#cuda-support-for-wsl2){: target="_blank"}** into the WSL 2 instance.
@@ -121,7 +121,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 {% capture yd_right %}
 ## <i class="fab fa-docker text-purple"></i> Docker Desktop
 
-1. Install WSL 2 and the Ubuntu 20.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
+1. Install WSL 2 and the Ubuntu 20.04/22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Install latest Docker Desktop for Windows [according to your applicable licensing terms](https://docs.docker.com/desktop/install/windows-install/){: target="_blank"}.
 4. Log in to the WSL 2 Linux instance.

--- a/wsl2.md
+++ b/wsl2.md
@@ -41,7 +41,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 
 > <i class="fas fa-microchip text-white"></i> **GPU:** Only GPUs with [Compute Capability](https://developer.nvidia.com/cuda-gpus){: target="_blank"} 7.0 or higher are supported on RAPIDS in WSL 2. 16GB or more of GPU RAM is recommended.
 
-> <i class="fas fa-download text-white"></i> **WSL 2 Instance:** Ubuntu 20.04/22.04 instance for WSL 2.
+> <i class="fas fa-download text-white"></i> **WSL 2 Instance:** Ubuntu 22.04 instance for WSL 2.
 
 ## <i class="far fa-comments text-white"></i> Connect
 > Join our community conversations about RAPIDS on WSL 2 using **[Twitter](https://twitter.com/rapidsai){: target="_blank"}**, **[Slack]({{ site.slack_invite }}){: target="_blank"}**, or ask a question on **[StackOverflow](https://stackoverflow.com/tags/rapids){: target="_blank"}**.
@@ -89,7 +89,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 {% capture yd_left %}
 ## <i class="fas fa-laptop-code"></i> Conda <br>(Preferred Method)
 
-1. Install WSL 2 and the Ubuntu 20.04/22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
+1. Install WSL 2 and the Ubuntu 22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Log in to the WSL 2 Linux instance.
 4. Install Conda in the WSL 2 Linux Instance using [our Conda instructions](https://rapids.ai/start.html#environment){: target="_blank"}.
@@ -105,7 +105,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 {% capture yd_mid %}
 ## <i class="fab fa-python text-purple"></i> pip
 
-1. Install WSL 2 and the Ubuntu 20.04/22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
+1. Install WSL 2 and the Ubuntu 22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Log in to the WSL 2 Linux instance.
 4. Follow **[this guide to install the CUDA Toolkit without drivers](https://docs.nvidia.com/cuda/wsl-user-guide/index.html#cuda-support-for-wsl2){: target="_blank"}** into the WSL 2 instance.
@@ -121,7 +121,7 @@ Windows users can now tap into GPU accelerated data science on their local machi
 {% capture yd_right %}
 ## <i class="fab fa-docker text-purple"></i> Docker Desktop
 
-1. Install WSL 2 and the Ubuntu 20.04/22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
+1. Install WSL 2 and the Ubuntu 22.04 package [using Microsoft's instructions](https://docs.microsoft.com/en-us/windows/wsl/install){: target="_blank"}.
 2. Install the [latest NVIDIA Drivers](https://www.nvidia.com/download/index.aspx){: target="_blank"} on the Windows host.
 3. Install latest Docker Desktop for Windows [according to your applicable licensing terms](https://docs.docker.com/desktop/install/windows-install/){: target="_blank"}.
 4. Log in to the WSL 2 Linux instance.


### PR DESCRIPTION
This PR updates our release selector for 23.02. @charlesbluca noticed that our Python versions have been incorrect for nightly versions of 23.02 (Python 3.9 has been dropped but has been showing on the release selector for nightly users).

@sevagh Can you please review the pip changes?

I would appreciate a critical eye from other reviewers as well. 🙏