### PR TITLE
Only allow CUDA 11.8 for Ubuntu 22.04

### DIFF
--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -469,6 +469,9 @@
                 }
                 if (method === "Docker") {
                     this.active_release = "Stable"
+                    if (this.active_os_ver === 'Ubuntu 22.04') {
+                        this.active_cuda_ver = '11.8';
+                    }
                 }
                 this.active_method = method;
             },

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -405,7 +405,7 @@
                     isDisabled = true;
                 }
                 if (this.active_additional_packages.includes("TensorFlow") && cuda_version !== "11.2") isDisabled = true;
-                if (this.active_os_ver === 'Ubuntu 22.04' && cuda_version !== '11.8') isDisabled = true;
+                if (this.active_os_ver === 'Ubuntu 22.04' && cuda_version !== '11.8' && this.active_method === 'Docker') isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {
@@ -415,7 +415,7 @@
             disableUnsupportedImgOS(os) {
                 var isDisabled = false;
                 if (this.active_arch === "arm" && os === "CentOS 7") isDisabled = true;
-                if (this.active_cuda_ver !== '11.8' && os === 'Ubuntu 22.04') isDisabled = true;
+                if (this.active_cuda_ver !== '11.8' && os === 'Ubuntu 22.04' && this.active_method === 'Docker') isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedImgType(type) {

--- a/_includes/selector.html
+++ b/_includes/selector.html
@@ -405,6 +405,7 @@
                     isDisabled = true;
                 }
                 if (this.active_additional_packages.includes("TensorFlow") && cuda_version !== "11.2") isDisabled = true;
+                if (this.active_os_ver === 'Ubuntu 22.04' && cuda_version !== '11.8') isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedPython(python_version) {
@@ -414,6 +415,7 @@
             disableUnsupportedImgOS(os) {
                 var isDisabled = false;
                 if (this.active_arch === "arm" && os === "CentOS 7") isDisabled = true;
+                if (this.active_cuda_ver !== '11.8' && os === 'Ubuntu 22.04') isDisabled = true;
                 return isDisabled;
             },
             disableUnsupportedImgType(type) {


### PR DESCRIPTION
Resolves https://github.com/rapidsai/docker/issues/533

CUDA 11.8 is only supported on Ubuntu 22.04, so disable various selections to enforce this.

Ref: https://github.com/rapidsai/docker/pull/526