### PR TITLE
Reorder page titles.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,6 +1,6 @@
 baseURL = 'https://rapids.ai/'
 languageCode = 'en-us'
-title = 'RAPIDS.ai'
+title = 'RAPIDS'
 enableRobotsTXT = true
 googleAnalytics = 'G-RKXFW6CM42'
 

--- a/content/_index.html
+++ b/content/_index.html
@@ -1,5 +1,5 @@
 ---
-title: RAPIDS.ai | GPU accelerated data science
+title: RAPIDS | GPU Accelerated Data Science
 description: homepage
 ---
 
@@ -8,10 +8,10 @@ description: homepage
 
   <!-- Announcements Shortcode (0-3x)-->
   <!-- UPDATE HERE -->
-  {{< announcements 
+  {{< announcements
     text-1="RAPIDS 23.02 Released" link-1="https://docs.rapids.ai/install#selector"
-    text-2="NVIDIA GTC March 20-23" link-2="https://www.nvidia.com/gtc/"  
-    text-3="Support for Python 3.10 in 23.02" link-3="https://docs.rapids.ai/notices/rsn0023/" 
+    text-2="NVIDIA GTC March 20-23" link-2="https://www.nvidia.com/gtc/"
+    text-3="Support for Python 3.10 in 23.02" link-3="https://docs.rapids.ai/notices/rsn0023/"
   >}}
 
     <!-- Intro -->
@@ -47,7 +47,7 @@ description: homepage
             <h2><i class="fa-thin fa-objects-column"></i> Faster Pandas <br> with cuDF</h2>
             <p>cuDF is a near drop in replacement to pandas for most use cases and has greatly improved performance. </p> <br>
             <a href="https://github.com/rapidsai/cudf/tree/branch-23.04/docs/cudf/source/user_guide/performance_comparisons.ipynb"  target="_blank">Run this benchmark yourself <i class="fa-solid fa-arrow-up-right"></i> </a>
-            
+
             <canvas id="cuDFchart" width="400" height="350"></canvas>
             <p class="is-size-7 has-text-grey">* Benchmark on AMD EPYC 7642 (using 1x 2.3GHz CPU core) w/ 512GB and NVIDIA A100 80GB (1x GPU) w/ pandas v1.5 and cuDF v23.02</p>
           </div>
@@ -93,7 +93,7 @@ description: homepage
             <code>nvidia-smi</code>
 
             <h3 class="mt-6 has-text-white">Install with Conda</h3>
-            <p><strong>1.</strong> If conda is not installed, download and run the conda install script</p>
+            <p><strong>1.</strong> If conda is not installed, download and run the install script:</p>
             <pre class="highlight use-white-copy"><code>wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
 bash Miniconda3-latest-Linux-x86_64.sh</code></pre>
             <br>
@@ -102,7 +102,7 @@ bash Miniconda3-latest-Linux-x86_64.sh</code></pre>
 
             <h3 class="mt-6 has-text-white">Install with pip</h3>
             <p><strong>1.</strong> Install via pip channels:</p>
-            <pre class="highlight use-white-copy"><code>pip install cudf-cu11 dask-cudf-cu11 --extra-index-url=https://pypi.nvidia.com 
+            <pre class="highlight use-white-copy"><code>pip install cudf-cu11 dask-cudf-cu11 --extra-index-url=https://pypi.nvidia.com
 pip install cuml-cu11 --extra-index-url=https://pypi.nvidia.com
 pip install cugraph-cu11 --extra-index-url=https://pypi.nvidia.com</code></pre>
 
@@ -114,7 +114,7 @@ pip install cugraph-cu11 --extra-index-url=https://pypi.nvidia.com</code></pre>
 
             <h2 class="mt-8 has-text-white"><i class="fa-light fa-gears"></i> Do I need an Advanced Install?</h2>
             <p> If you want to use Docker, WSL2, have an uncommon OS, hardware configuration, environment, or
-              need specific versioning such as <code>CUDA 11.5</code> or <code>Python 3.8</code> then you should use the
+              need specific versions such as <code>CUDA 11.5</code> or <code>Python 3.8</code> then you should use the
               installation selector in our
               <a href="https://docs.rapids.ai/install" target="_blank">Advanced Installations Page <i class="fa-solid fa-arrow-up-right"></i> </a>
             </p>
@@ -274,7 +274,7 @@ pip install cugraph-cu11 --extra-index-url=https://pypi.nvidia.com</code></pre>
         <div class="columns">
           <div class="column is-half">
             <h2><i class="fa-regular fa-triangle-exclamation"></i> RAPIDS Support Notices </h2>
-            <p> Get the full list of developer updates and notices (RSN) that may effect your projects on the <a
+            <p> Get the full list of developer updates and notices (RSN) that may affect your projects on the <a
                 href="https://docs.rapids.ai/notices" target="_blank"> RSN Documentation Page <i class="fa-solid fa-arrow-up-right"></i></a> </p>
           </div>
           <div class="column is-half">

--- a/content/branding/_index.html
+++ b/content/branding/_index.html
@@ -1,5 +1,5 @@
 ---
-title: RAPIDS.ai | Branding and Guides
+title: Branding and Guides | RAPIDS
 description: RAPIDS branding style guides, and logos
 ---
 
@@ -13,7 +13,7 @@ description: RAPIDS branding style guides, and logos
       <div class="columns">
         <div class="column is-half">
           <p>This page contains assets, guides, and citation formats to help you style RAPIDS communications consistently and clearly.</p>
-          
+
           <br>
 
           <h3>Design and Brand Guide</h3>
@@ -23,7 +23,7 @@ description: RAPIDS branding style guides, and logos
 
           <h3>Open Sans Font</h3>
           <a href="https://fonts.google.com/specimen/Open+Sans"> Use via Google Fonts <i class="fa-solid fa-arrow-up-right"></i></a>
-        
+
           <h2 class="mt-5"><i class="fa-light fa-flask"></i> RAPIDS Citation Guide</h2>
           <p>We welcome citations. If you use RAPIDS in a publication, please use citations in the following format (BibTeX entry for LaTeX):</p>
           <pre class="highlight mt-5"><code>@Manual{

--- a/content/drafts/events.html
+++ b/content/drafts/events.html
@@ -1,5 +1,5 @@
 ---
-title: RAPIDS.ai | Events
+title: Events | RAPIDS
 description: Upcoming and past RAPIDS events
 draft: true
 ---
@@ -29,7 +29,7 @@ draft: true
                         </div>
                     </div>
                 </template>
-            </div> 
+            </div>
         </div>
 
     </div>

--- a/content/drafts/rsn.html
+++ b/content/drafts/rsn.html
@@ -1,5 +1,5 @@
 ---
-title: RAPIDS.ai | RAPIDS Support Notices
+title: RAPIDS Support Notices | RAPIDS
 description: RAPIDS Developer and Support Notices
 draft: true
 ---
@@ -32,7 +32,7 @@ draft: true
                         </div>
                     </div>
                 </template>
-            </div> 
+            </div>
         </div>
 
     </div>

--- a/content/drafts/templates.html
+++ b/content/drafts/templates.html
@@ -1,6 +1,6 @@
 ---
-title: RAPIDS.ai | Site Template
-description: Design guides for Rapids.ai
+title: Site Template | RAPIDS
+description: Design guides for rapids.ai
 draft: true
 ---
 
@@ -293,7 +293,7 @@ draft: true
     {{< post-tweets >}}
   </section>
 
-  <section class="padding-bottom-slant"> 
+  <section class="padding-bottom-slant">
     <!-- Hero Shortcode -->
     {{< open-source >}}
 

--- a/content/ecosystem/_index.html
+++ b/content/ecosystem/_index.html
@@ -1,5 +1,5 @@
 ---
-title: RAPIDS.ai | Ecosystem
+title: Ecosystem | RAPIDS
 description: RAPIDS libraries, frameworks, extensions and more
 ---
 

--- a/content/featured/_index.html
+++ b/content/featured/_index.html
@@ -1,5 +1,5 @@
 ---
-title: RAPIDS.ai | Featured Content
+title: Featured Content | RAPIDS
 description: Featured Content about RAPIDS
 ---
 

--- a/content/learn-more/_index.html
+++ b/content/learn-more/_index.html
@@ -1,5 +1,5 @@
 ---
-title: RAPIDS.ai | Learn More
+title: Learn More | RAPIDS
 description: Use cases and enterprise topics
 ---
 
@@ -41,7 +41,7 @@ description: Use cases and enterprise topics
         <div class="column is-one-third">
           <h2><i class="fa-light fa-house-laptop"></i> Familiar </h2>
           <p>Utilizing NVIDIA CUDA primitives for low-level compute optimization, RAPIDS exposes GPU parallelism and high-bandwidth memory speed through user-friendly interfaces:</p> <br>
-          
+
           <div class="content is-size-6-half">
             <i class="fa fa-caret-right"></i> Dataframe processing with <a href="https://github.com/rapidsai/cudf" target="_blank">cuDF</a> (similar API to pandas) <br>
             <i class="fa fa-caret-right"></i> Machine learning with <a href="https://github.com/rapidsai/cuml" target="_blank">cuML</a> (similar API to scikit-learn) <br>
@@ -52,14 +52,14 @@ description: Use cases and enterprise topics
             <i class="fa fa-caret-right"></i> Seamless cross-filtered dashboards with <a href="https://github.com/rapidsai/cuxfilter" target="_blank">cuxfilter</a> <br>
             <i class="fa fa-caret-right"></i> Low level compute primitives with <a href="https://github.com/rapidsai/raft" target="_blank">RAFT</a> <br>
             <i class="fa fa-caret-right"></i>  Apache Spark acceleration with <a href="https://nvidia.github.io/spark-rapids/" target="_blank">Spark RAPIDS</a> <br><br>
-            
+
             and <a href="https://github.com/rapidsai" target="_blank">many more projects</a>...
           </div>
         </div>
         <div class="column is-one-third">
           <h2><i class="fa-light fa-layer-plus"></i> Scalable </h2>
           <p> RAPIDS delivers impressive acceleration from on a single GPU desktop system all the way to MNMG (multi-node multi-GPU) configurations on an expansive range of <a href="https://www.nvidia.com/en-us/deep-learning-ai/solutions/data-science/" target="_blank">NVIDIA hardware</a>. </p> <br>
-          
+
           <div class="content is-size-6-half">
             <i class="fa fa-caret-right"></i> Impressive single GPU performance out of the box <br>
             <i class="fa fa-caret-right"></i> MNMG with <a href="https://docs.dask.org/en/stable/gpu.html"  target="_blank"> RAPIDS + Dask</a> and <a href="https://nvidia.github.io/spark-rapids/" target="_blank">RAPIDS + Spark</a> <br>
@@ -140,7 +140,7 @@ description: Use cases and enterprise topics
       <div class="columns">
         <div class="column is-one-third">
           <h2><i class="fa-light fa-briefcase"></i> Business </h2>
-          <p>Use RAPIDS directly or through NVIDIA AI Enterprise, which provides extensive optimization, certified hardware profiles, and direct IT support. 
+          <p>Use RAPIDS directly or through NVIDIA AI Enterprise, which provides extensive optimization, certified hardware profiles, and direct IT support.
           <a href="https://www.nvidia.com/en-us/data-center/products/ai-enterprise/" target="_blank"> Read more about NVIDIA AI Enterprise<i class="fa-solid fa-arrow-up-right"></i> </a> </p>
         </div>
         <div class="column is-one-third">

--- a/content/news/_index.html
+++ b/content/news/_index.html
@@ -1,5 +1,5 @@
 ---
-title: RAPIDS.ai | News
+title: News | RAPIDS
 description: Latest News about RAPIDS
 ---
 
@@ -18,7 +18,7 @@ description: Latest News about RAPIDS
         </div>
         <div class="column is-one-third">
           <h2><i class="fa-regular fa-message-quote"></i> Blog Posts </h2>
-          <p> A rich collection of release announcements, RAPIDS data science knowledge, and user guides.</p> 
+          <p> A rich collection of release announcements, RAPIDS data science knowledge, and user guides.</p>
           <a href="https://medium.com/rapids-ai" target="_blank">Medium Blog Posts <i class="fa-solid fa-arrow-up-right"></i> </a>
         </div>
         <div class="column is-one-third">
@@ -35,7 +35,7 @@ description: Latest News about RAPIDS
   </div>
 
   <section class="section padding-bottom-slant">
-  
+
     <!-- Posts and Tweets -->
     {{< post-tweets >}}
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,11 +7,11 @@
     {{ end }}
   </title>
 
-  <meta name="description" content="RAPIDS.ai | GPU accelerated data science">
+  <meta name="description" content="RAPIDS | GPU Accelerated Data Science">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta name="theme-color" content="#fafafa">
 
-  <meta property="og:title" content="RAPIDS.ai | GPU accelerated data science">
+  <meta property="og:title" content="RAPIDS | GPU Accelerated Data Science">
   <meta property="og:description" content="Open source GPU accelerated data science libraries">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://rapids.ai/">
@@ -19,7 +19,7 @@
 
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:site" content="https://rapids.ai/" />
-  <meta name="twitter:title" content="RAPIDS.ai | GPU accelerated data science" />
+  <meta name="twitter:title" content="RAPIDS | GPU Accelerated Data Science" />
   <meta name="twitter:description" content="Open source GPU accelerated data science libraries" />
   <meta name="twitter:image" content="/images/RAPIDS-logo-white.png" />
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,6 +1,6 @@
 /* ============================
-   Custom CSS for RAPIDS.ai
-   Overrides for base Bluma.css
+   Custom CSS for rapids.ai
+   Overrides for base Bulma.css
    =========================== */
 
 
@@ -588,4 +588,3 @@ button:hover {
 .has-text-rapids-teal {
   color: #36c9dd;
 }
-

--- a/static/manifest.json
+++ b/static/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "RAPIDS GPU accelerated data science",
-  "short_name": "RAPIDS.ai",
+  "short_name": "RAPIDS",
   "theme_color": "#fff",
   "background_color": "#fff",
   "display": "browser",

--- a/static/site.webmanifest
+++ b/static/site.webmanifest
@@ -1,6 +1,6 @@
 {
   "short_name": "RAPIDS",
-  "name": "RAPIDS.ai",
+  "name": "RAPIDS",
   "icons": [{
     "src": "icon.png",
     "type": "image/png",


### PR DESCRIPTION
This reorders page titles so that they look like `Ecosystem | RAPIDS` instead of `RAPIDS.ai | Ecosystem`. This aligns with best-practices guides I found for SEO and accessibility:

https://www.youtube.com/watch?v=9mVQaePha7M&ab_channel=Nomensa

https://blog.hubspot.com/blog/tabid/6307/bid/5984/spilling-seo-juice-3-dos-and-don-ts-for-writing-great-page-titles.aspx

https://webmasters.stackexchange.com/questions/16251/should-site-title-be-before-or-after-page-title