### PR TITLE
Add redirect to RAPIDS tutorial GitHub repo

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -12,13 +12,13 @@
 /hpc.html              https://docs.rapids.ai/deployment/stable/hpc.html
 /hpo                   https://docs.rapids.ai/deployment/stable/examples/index.html
 /hpo.html              https://docs.rapids.ai/deployment/stable/examples/index.html
+/introgtc2023          https://github.com/shwina/rapids-tutorial-gtc-2023
 /pip                   https://docs.rapids.ai/install#pip
 /pip.html              https://docs.rapids.ai/install#pip
 /plotly                https://docs.rapids.ai/visualization
 /plotly.html           https://docs.rapids.ai/visualization
 /slack-invite          https://join.slack.com/t/rapids-goai/shared_invite/zt-trnsul8g-Sblci8dk6dIoEeGpoFcFOQ
 /smsl                  https://studiolab.sagemaker.aws/import/github/rapidsai-community/rapids-smsl/blob/main/rapids-smsl.ipynb
-/introgtc2023          https://github.com/shwina/rapids-tutorial-gtc-2023
 /start                 https://docs.rapids.ai/install
 /start.html            https://docs.rapids.ai/install
 /wsl2                  https://docs.rapids.ai/install#WSL2

--- a/_redirects
+++ b/_redirects
@@ -18,6 +18,7 @@
 /plotly.html           https://docs.rapids.ai/visualization
 /slack-invite          https://join.slack.com/t/rapids-goai/shared_invite/zt-trnsul8g-Sblci8dk6dIoEeGpoFcFOQ
 /smsl                  https://studiolab.sagemaker.aws/import/github/rapidsai-community/rapids-smsl/blob/main/rapids-smsl.ipynb
+/introgtc2023          https://github.com/shwina/rapids-tutorial-gtc-2023
 /start                 https://docs.rapids.ai/install
 /start.html            https://docs.rapids.ai/install
 /wsl2                  https://docs.rapids.ai/install#WSL2


### PR DESCRIPTION
In preparation for GTC, add a redirect to the (currently private) tutorial repo.

cc: @JohnZed 