### PR TITLE
Test documentation proxies

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -25,3 +25,9 @@
 /wsl2.html             https://docs.rapids.ai/install#WSL2
 /xgboost               https://xgboost.readthedocs.io/en/stable/gpu/index.html
 /xgboost.html          https://xgboost.readthedocs.io/en/stable/gpu/index.html
+
+
+/cudf/ /cudf/stable/
+/cudf/stable/* https://d1664dvumjb44w.cloudfront.net/cudf/23.06/html/:splat 200
+/cudf/23.06/* https://d1664dvumjb44w.cloudfront.net/cudf/23.06/html/:splat 200
+/cudf/23.04/* https://d1664dvumjb44w.cloudfront.net/cudf/23.04/html/:splat 200


### PR DESCRIPTION
This PR tests Netlify's proxy functionality with the new CloudFront Distribution that we've put in front of the S3 bucket that holds our docs.