### PR TITLE
Fix quick installation command.

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -100,7 +100,7 @@ description: homepage
 bash Miniconda3-latest-Linux-x86_64.sh</code></pre>
             <br>
             <p><strong>2.</strong> Then quick install RAPIDS with:</p>
-            <pre class="highlight use-white-copy"><code>conda create -n rapids-23.04 -c rapidsai -c conda-forge -c nvidia  \ rapids=23.04 python=3.10 cudatoolkit=11.8</code></pre>
+            <pre class="highlight use-white-copy"><code>conda create -n rapids-23.04 -c rapidsai -c conda-forge -c nvidia rapids=23.04 python=3.10 cudatoolkit=11.8</code></pre>
 
             <h3 class="mt-6 has-text-white">Install with pip</h3>
             <p><strong>1.</strong> Install via pip channels. <br> Not all RAPIDS libraries are currently available:</p>


### PR DESCRIPTION
The "quick install" command doesn't work when copied because it contains an escaping backslash `\` that isn't followed by a newline character. We can either insert a newline OR remove the backslash. I prefer to remove the backslash and treat it as a one-liner.