### PR TITLE
Fix home page layout

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -282,7 +282,7 @@ pip install cugraph-cu11 --extra-index-url=https://pypi.nvidia.com</code></pre>
             <p> Get the full list of developer updates and notices (RSN) that may affect your projects on the <a
                 href="https://docs.rapids.ai/notices" target="_blank"> RSN Documentation Page <i class="fa-solid fa-arrow-up-right"></i></a> </p>
           </div>
-          <div class="column is-half">
+          <div class="column is-one-third">
             <h2><i class="fa-regular fa-books"></i> RAPIDS News </h2>
             <p> Find our highlighted content, including videos, talks, posts, guides and more in the <a href="/featured"> Featured Content Page <i class="fa-solid fa-arrow-up-right"></i></a> </p>
           </div>


### PR DESCRIPTION
Looks like this home page layout is larger than it should be.

![image](https://github.com/rapidsai/rapids.ai/assets/7400326/64957e47-2f0a-4ec6-b15b-34af45b8faf7)

Changing the CSS class from `is-half` to `is-one-third` like the other sections seems to resolve it.