### PR TITLE
Add line break to make text more mobile friendly.

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -15,7 +15,7 @@ title: RAPIDS | GPU Accelerated Data Science
             <i class="fa-solid fa-circle fa-stack-2x"></i>
             <i class="fa-sharp fa-regular fa-bell-on fa-bounce fa-stack-1x fa-inverse"></i>
           </span>
-          <button class="button-rapids-purple"><strong>Watch the replay:</strong> <br/> AI and Data Science Virtual Summit Hosted by NVIDIA</button>
+          <button class="button-rapids-purple"><strong>Watch the replay:</strong> <br/> AI and Data Science Virtual Summit <br/> Hosted by NVIDIA</button>
         </a>
 
         <a href="/cudf-pandas" target='_blank' class="hero-announce">


### PR DESCRIPTION
There’s a UI issue on mobile with the announcements. The AI and Data Science Virtual Summit overruns the page on mobile, causing scrolling to behave poorly. We probably need a proper CSS fix for this to allow line wrapping but for now I’m just going to insert a linebreak.

<img width="375" alt="image" src="https://github.com/rapidsai/rapids.ai/assets/3943761/98818022-9a89-4e61-9916-06c184101d42">
