### PR TITLE
Drop leading zero in pip install

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -199,10 +199,10 @@ bash Miniconda3-latest-Linux-x86_64.sh</code></pre>
                     <p>Install via the NVIDIA PyPI index:</p>
                     <pre class="highlight use-white-copy"><code>pip install \
 --extra-index-url=https://pypi.nvidia.com \
-cudf-cu12==24.02.* \
-dask-cudf-cu12==24.02.* \
-cuml-cu12==24.02.* \
-cugraph-cu12==24.02.*</code></pre>
+cudf-cu12==24.2.* \
+dask-cudf-cu12==24.2.* \
+cuml-cu12==24.2.* \
+cugraph-cu12==24.2.*</code></pre>
 
                     <h3 class="mt-6 text-white">Install with Docker</h3>
                     <p>Check that you have the <a href="https://docs.rapids.ai/install#docker" target="_blank">required


### PR DESCRIPTION
Same reasons as in https://github.com/rapidsai/docs/pull/479
