### PR TITLE
Remove centos refs from homepage

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -155,7 +155,7 @@
                     <p><strong>A.</strong> NVIDIA Volta™ or higher GPU with <a
                             href="https://developer.nvidia.com/cuda-gpus" target="_blank">compute capability 7.0+
                             <i class="fa-solid fa-arrow-up-right"></i></a></p>
-                    <p><strong>B.</strong> Ubuntu 20.04 or 22.04, CentOS 7, Rocky Linux 8, or WSL2 on Windows 11</p>
+                    <p><strong>B.</strong> Ubuntu 20.04 or 22.04, Rocky Linux 8, or WSL2 on Windows 11</p>
                     <p><strong>C.</strong> Recent <a href="https://docs.nvidia.com/deploy/cuda-compatibility/index.html"
                             target="_blank"> CUDA version <em>and</em> NVIDIA driver pairs</a>. Check yours with:
                         <code>nvidia-smi</code>


### PR DESCRIPTION
Following the removal of Cent OS 7 support across RAPIDS, this PR removes any Cent OS 7 references from the home page