### PR TITLE
Fix devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,8 +7,7 @@
     "features": {
         "ghcr.io/devcontainers/features/go:1": {},
         "ghcr.io/devcontainers/features/node:1": {
-            "version": "none",
-            "nodeGypDependencies": false
+            "version": "latest"
         },
         "ghcr.io/eitsupi/devcontainer-features/jq-likes:2": {
             "jqVersion": "latest",

--- a/scripts/get_medium.py
+++ b/scripts/get_medium.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import requests
 import xmltodict
 import yaml


### PR DESCRIPTION
This PR fixes the devcontainer, which was erroring when failing to find `npm`. I believe this is because the Node feature had feature `"none"` instead of `"latest"`. I also made the `get_medium.py` script executable.
