### PR TITLE
Minor edits to polars gpu engine page on rapids.ai

### DIFF
--- a/layouts/page/polars-gpu-engine.html
+++ b/layouts/page/polars-gpu-engine.html
@@ -2,7 +2,7 @@
 
 <!-- Hero Partial -->
 {{ partial "hero.html" (dict
-"text" "Polars GPU engine powered by cuDF"
+"text" "Polars GPU engine powered by cuDF [Open Beta]"
 "btn_text" "Get Started"
 "btn_link" "#get-started"
 ) }}
@@ -12,7 +12,7 @@
   <div class="col">
     <div class="container">
 
-      <h1 class="text-center mb-10"> BRINGING ACCELERATED COMPUTING TO POLARS <br/> [Open Beta] </h1>
+      <h1 class="text-center mb-10"> BRINGING ACCELERATED COMPUTING TO POLARS </h1>
       <div class="row">
         <div class="col-md-4 py-3">
           <h2><i class="fa-light fa-file-binary"></i> Zero Code Change</h2>

--- a/layouts/page/polars-gpu-engine.html
+++ b/layouts/page/polars-gpu-engine.html
@@ -307,7 +307,7 @@
   new Chart(ctx1, {
     type: 'bar',
     data: {
-      labels: ['20GB', '40GB', '60GB'],
+      labels: ['20GB', '40GB', '80GB'],
       datasets: [
         {
           label: 'Polars (CPU)',


### PR DESCRIPTION
Did the following edits-

1. Dataset sizes in the x-axis for the 'time vs dataset size' benchmark graph were [20GB,40GB,60GB]. However, the perflab experiments were done on [20GB, 40GB, 80GB]. See data [HERE](https://nvidia-my.sharepoint.com/:x:/r/personal/manass_nvidia_com/Documents/TPCH-Polars%20Update.xlsx?d=wf3ff2e0bc5fc44dc86b08a4bfed7e79b&csf=1&web=1&e=aGKSC5) (Tab: Aggregate (Datasets)). Changed 60GB to 80GB

2. Changed the location of [Open Beta] to align with the originally decided content page layout- https://docs.google.com/document/d/1h2Ynp0sniNuQ1k7Cfx64DYauaLJnadIkVpWCrXudaK0/edit