### PR TITLE
Make 404 Link relative

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -8,7 +8,7 @@
       <p class="fw-semibold fs-3 lh-xs text-white mb-2">
         Page Not Found
       </p>
-      <button class="text-rapids-teal border-rapids-teal"><a href="https://www.rapids.ai">Head Back</a></button>
+      <button class="text-rapids-teal border-rapids-teal"><a href="/">Head Back</a></button>
     </div>
     <div class="top-slant-container">
       <div class="top-slant-up bg-white"></div>


### PR DESCRIPTION
This PR adjusts the 404 page link to be relative instead of absolute.