### PR TITLE
Fix headless `_partners` bundle

### DIFF
--- a/content/_partners/_index.md
+++ b/content/_partners/_index.md
@@ -1,3 +1,7 @@
 ---
-headless: true
+cascade:
+  build:
+    list: never
+    publishResources: false
+    render: never
 ---

--- a/content/drafts/_index.md
+++ b/content/drafts/_index.md
@@ -1,0 +1,4 @@
+---
+cascade:
+  draft: true
+---

--- a/content/drafts/events.md
+++ b/content/drafts/events.md
@@ -1,7 +1,6 @@
 ---
 title: Events | RAPIDS
 description: Upcoming and past RAPIDS events
-draft: true
 # TODO: remove body_class once CSS is refactored and scoped properly
 body_class: landing-page
 layout: events

--- a/content/drafts/rsn.md
+++ b/content/drafts/rsn.md
@@ -1,7 +1,6 @@
 ---
 title: RAPIDS Support Notices | RAPIDS
 description: RAPIDS Developer and Support Notices
-draft: true
 # TODO: remove body_class once CSS is refactored and scoped properly
 body_class: landing-page
 layout: rsn

--- a/content/drafts/templates.md
+++ b/content/drafts/templates.md
@@ -1,7 +1,6 @@
 ---
 title: Site Template | RAPIDS
 description: Design guides for rapids.ai
-draft: true
 # TODO: remove body_class once CSS is refactored and scoped properly
 body_class: landing-page
 layout: templates

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -8,7 +8,7 @@ services:
     ID: G-RKXFW6CM42
 
 disableKinds: [taxonomy, term]
-
+enableGitInfo: true
 sitemap:
   changefreq: monthly
   filename: sitemap.xml

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,7 +4,7 @@ command = "./build.sh"
 
 [build.environment]
 GO_VERSION = "1.21.3"
-HUGO_VERSION = "0.121.1"
+HUGO_VERSION = "0.124.1"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,10 +8,6 @@ HUGO_VERSION = "0.124.1"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
-# Build drafts on PR previews
-[context.deploy-preview]
-  command = "./build.sh --buildDrafts"
-
 # Setting HUGO_ENV != "production" prevents
 # Google Analytics from being loaded on PR previews
 [context.deploy-preview.environment]

--- a/vercel.sh
+++ b/vercel.sh
@@ -26,7 +26,7 @@ install_dependencies() {
   echo "installing hugo"
   # TODO: move hugo version to its own file so it can be easily parsed by devcontainer
   # init scripts and renovate can update it.
-  HUGO_VERSION="0.121.1"
+  HUGO_VERSION="0.124.1"
   HUGO_URL="https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.tar.gz"
   curl -sSL "${HUGO_URL}" | tar -zx -C "${INSTALL_PREFIX}/bin"
 


### PR DESCRIPTION
The `_partners` bundle is intended to be headless, but it currently shows up on our sitemap.

This PR includes some changes to ensure that the `_partners` bundle is actually headless.

It updates some frontmatter and the Hugo version. The older Hugo version was not respecting the headless frontmatter.

It also sets `enableGitInfo: true` in the `hugo.yaml` config, since this seems to be required to get Vercel to show the `lastmod` date in the sitemaps.

Note, this doesn't update Hugo to the latest version since that also requires updating our theme, Docsy, which is a bit more involved. That'll come later.