### PR TITLE
Updates cuGraph benchmarks to reflect latest NetworkX zero code change results

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -615,7 +615,7 @@ cugraph-cu12==24.10.*</code></pre>
     new Chart(ctx3, {
         type: 'bar',
         data: {
-            labels: [['Weakly Connected', 'Components'], 'Triangles', 'PageRank', 'Louvain', ['Betweenness', 'Centrality k=100']],
+            labels: ['WCC', 'Triangles', 'PageRank', 'Louvain', 'BC k=100'],
             datasets: [{
                 label: 'NetworkX+cuGraph vs NetworkX speedup',
                 data: [24, 137, 177, 195, 487],

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -132,7 +132,7 @@
                 </div>
                 <div class="col-md-4 py-3">
                     <h2><i class="fa-light fa-circle-nodes"></i> Faster NetworkX <br> with cuGraph</h2>
-                    <p>cuGraph accelerates NetworkX with zero code changes for much greater performance at scale.</p>
+                    <p>cuGraph accelerates NetworkX with zero code changes for much greater performance at scale.</p> <br>
                     <a href="https://github.com/rapidsai/cugraph/blob/branch-24.10/benchmarks/nx-cugraph/pytest-based"
                         target="_blank">Run this benchmark yourself <i class="fa-solid fa-arrow-up-right"></i> </a>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -615,7 +615,7 @@ cugraph-cu12==24.10.*</code></pre>
     new Chart(ctx3, {
         type: 'bar',
         data: {
-            labels: ['Weakly Connected Components', 'Triangles', 'PageRank', 'Louvain', 'Betweenness Centrality k=100'],
+            labels: ['WCC', 'Triangles', 'PageRank', 'Louvain', 'BC k=100'],
             datasets: [{
                 label: 'NetworkX+cuGraph vs NetworkX speedup',
                 data: [24, 137, 177, 195, 487],

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -615,7 +615,7 @@ cugraph-cu12==24.10.*</code></pre>
     new Chart(ctx3, {
         type: 'bar',
         data: {
-            labels: ['WCC', 'Triangles', 'PageRank', 'Louvain', 'BC k=100'],
+            labels: [['Weakly Connected', 'Components'], 'Triangles', 'PageRank', 'Louvain', ['Betweenness', 'Centrality k=100']],
             datasets: [{
                 label: 'NetworkX+cuGraph vs NetworkX speedup',
                 data: [24, 137, 177, 195, 487],

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -138,7 +138,8 @@
 
                     <canvas id="cuGraphChart" width="400" height="350"></canvas>
                     <p class="fs-8 text-muted">* Benchmark on Intel(R) Xeon(R) w9-3495X w/ 250 GB and
-                        NVIDIA A100 80GB (1x GPU) w/ NetworkX v3.4.1 and cuGraph/nx-cugraph v24.10</p>
+                        NVIDIA A100 80GB (1x GPU) w/ NetworkX v3.4.1 and cuGraph/nx-cugraph v24.10;
+                        WCC = Weakly COnnected Components; Betweenness = Betweenness Centrality with k=100</p>
                 </div>
             </div>
         </div>
@@ -615,7 +616,7 @@ cugraph-cu12==24.10.*</code></pre>
     new Chart(ctx3, {
         type: 'bar',
         data: {
-            labels: ['WCC', 'Triangles', 'PageRank', 'Louvain', 'BC k=100'],
+            labels: ['WCC', 'Triangles', 'PageRank', 'Louvain', 'Betweenness'],
             datasets: [{
                 label: 'NetworkX+cuGraph vs NetworkX speedup',
                 data: [24, 137, 177, 195, 487],

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -112,7 +112,7 @@
             <div class="row mt-5">
                 <div class="col-md-4 py-3">
                     <h2><i class="fa-thin fa-objects-column"></i> Faster Pandas <br> with cuDF</h2>
-                    <p>cuDF accelerates pandas with zero code change and brings greatly improved performance.</p> <br>
+                    <p>cuDF accelerates pandas with zero code changes and brings greatly improved performance.</p> <br>
                     <a href="https://github.com/rapidsai/cudf/blob/branch-24.10/docs/cudf/source/user_guide/performance-comparisons/performance-comparisons.ipynb"
                         target="_blank">Run this benchmark yourself <i class="fa-solid fa-arrow-up-right"></i> </a>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -112,7 +112,7 @@
             <div class="row mt-5">
                 <div class="col-md-4 py-3">
                     <h2><i class="fa-thin fa-objects-column"></i> Faster Pandas <br> with cuDF</h2>
-                    <p>cuDF accelerates pandas with no code change and brings greatly improved performance.</p> <br>
+                    <p>cuDF accelerates pandas with zero code change and brings greatly improved performance.</p> <br>
                     <a href="https://github.com/rapidsai/cudf/blob/branch-24.10/docs/cudf/source/user_guide/performance-comparisons/performance-comparisons.ipynb"
                         target="_blank">Run this benchmark yourself <i class="fa-solid fa-arrow-up-right"></i> </a>
 
@@ -132,14 +132,13 @@
                 </div>
                 <div class="col-md-4 py-3">
                     <h2><i class="fa-light fa-circle-nodes"></i> Faster NetworkX <br> with cuGraph</h2>
-                    <p>cuGraph makes migration from NetworkX easy, accelerates graph analytics, and allows scaling far
-                        beyond existing tools. </p>
-                    <a href="https://github.com/rapidsai/cugraph/blob/branch-24.10/notebooks/cugraph_benchmarks/synth_release_single_gpu.ipynb"
+                    <p>cuGraph accelerates NetworkX with zero code changes for much greater performance at scale.</p>
+                    <a href="https://github.com/rapidsai/cugraph/blob/branch-24.10/benchmarks/nx-cugraph/pytest-based"
                         target="_blank">Run this benchmark yourself <i class="fa-solid fa-arrow-up-right"></i> </a>
 
                     <canvas id="cuGraphChart" width="400" height="350"></canvas>
-                    <p class="fs-8 text-muted">* Benchmark on AMD EPYC 7642 (using 1x 2.3GHz CPU core) w/ 512GB and
-                        NVIDIA A100 80GB (1x GPU) w/ NetworkX v3.0 and cuGraph v23.02</p>
+                    <p class="fs-8 text-muted">* Benchmark on Intel(R) Xeon(R) w9-3495X w/ 250 GB and
+                        NVIDIA A100 80GB (1x GPU) w/ NetworkX v3.4.1 and cuGraph/nx-cugraph v24.10</p>
                 </div>
             </div>
         </div>
@@ -616,10 +615,10 @@ cugraph-cu12==24.10.*</code></pre>
     new Chart(ctx3, {
         type: 'bar',
         data: {
-            labels: ['Jaccard', 'Core Number', 'Louvain', 'PageRank', 'Katz'],
+            labels: ['Weakly Connected Components', 'Triangles', 'PageRank', 'Louvain', 'Betweenness Centrality k=100'],
             datasets: [{
-                label: 'cuGraph vs NetworkX speedup',
-                data: [7, 10, 35, 42, 87],
+                label: 'NetworkX+cuGraph vs NetworkX speedup',
+                data: [24, 137, 177, 195, 487],
                 backgroundColor: [
                     'rgb(115, 6, 255, .80)'
                 ]
@@ -653,7 +652,7 @@ cugraph-cu12==24.10.*</code></pre>
                 },
                 title: {
                     display: true,
-                    text: 'Performance on ~8,192 vertices x ~262,144 edges'
+                    text: 'Performance on 4.8M nodes x 69M edges'
                 }
             },
             layout: {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -139,7 +139,7 @@
                     <canvas id="cuGraphChart" width="400" height="350"></canvas>
                     <p class="fs-8 text-muted">* Benchmark on Intel(R) Xeon(R) w9-3495X w/ 250 GB and
                         NVIDIA A100 80GB (1x GPU) w/ NetworkX v3.4.1 and cuGraph/nx-cugraph v24.10;
-                        WCC = Weakly COnnected Components; Betweenness = Betweenness Centrality with k=100</p>
+                        WCC = Weakly Connected Components; Betweenness = Betweenness Centrality with k=100</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This updates the cuGraph benchmarks to show results for latest NetworkX zero code change results, as well as the messaging around "zero code change", which is consistent with cuDF's "no code change" Pandas messaging (this also changes cuDF's "no code change" to "zero code change" for consistency).