### PR TITLE
Replace cuDF notebook with non-Drive link

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -212,7 +212,7 @@ cugraph-cu12==24.10.*</code></pre>
                 <div class="col-md-6 py-3">
                     <h2 class="text-white"><i class="fa-light fa-gauge-circle-bolt"></i> Test Drive cuDF</h2>
                     <p>Try out cuDF pandas Accelerator Mode, with a free required account, right now by <a
-                            href="https://nvda.ws/rapids-cudf" target="_blank">launching Google Colab <i
+                            href="https://nvda.ws/3yW6j22" target="_blank">launching Google Colab <i
                                 class="fa-solid fa-arrow-up-right"></i> </a> </p>
 
                     <br><br>


### PR DESCRIPTION
Update “Test Drive cuDF” on homepage to new notebook link