### PR TITLE
Fix Colab notebook URLs on cudf-pandas overview page

### DIFF
--- a/layouts/page/cudf-pandas.html
+++ b/layouts/page/cudf-pandas.html
@@ -157,9 +157,9 @@
         <div class="col py-3">
           <h2><i class="fa-light fa-bookmark"></i> Try Now on Colab</h2>
           {{ $colabImg := ((site.GetPage "_partners/google-colab").Resources.Get "logo.png").Resize "200x" }}
-          <a href="https://nvda.ws/4eKlWZW" target="_blank"><img src="{{ $colabImg.RelPermalink }}"></a>
+          <a href="https://nvda.ws/3yW6j22" target="_blank"><img src="{{ $colabImg.RelPermalink }}"></a>
           <p>Take cuDF's new pandas accelerator mode for a test-drive in a free GPU-enabled notebook environment using
-            your Google account by <a href="https://nvda.ws/4eKlWZW" target="_blank">launching on Colab <i
+            your Google account by <a href="https://nvda.ws/3yW6j22" target="_blank">launching on Colab <i
                 class="fa-solid fa-arrow-up-right"></i> </a></p>
           <br>
           <p>cuDF's pandas accelerator mode is part of the cuDF package and works smoothly with all RAPIDS libraries.


### PR DESCRIPTION
This PR updates the Colab notebook URLs on the cudf-pandas page to correctly redirect to the cuDF pandas notebooks rather than Polars.