### PR TITLE
Update cuCIM description to mention similar Python APIs.

### DIFF
--- a/layouts/page/ecosystem.html
+++ b/layouts/page/ecosystem.html
@@ -92,7 +92,7 @@
             <span class="tags-item text-white border-white"><i class="fa-solid fa-tag"></i> PYTHON / C++ </span>
           </div>
           <p class="text-white"> cuML is a library for executing machine learning algorithms on GPUs with an API
-            that closely follows the Scikit-Learn API. Reduce the time to fit your model from hours or minutes to
+            that closely follows the scikit-learn API. Reduce the time to fit your model from hours or minutes to
             seconds.</p>
           <a href="https://github.com/rapidsai/cuml" target="_blank">GitHub <i class="fa-solid fa-arrow-up-right"></i>
           </a> <br>
@@ -239,7 +239,7 @@
             <span class="tags-item text-white border-white"><i class="fa-solid fa-tag"></i> PYTHON </span>
           </div>
           <p class="text-white"> Greatly accelerate your computer vision and image processing tasks, especially for
-            biomedical imaging.</p>
+            biomedical imaging. The cuCIM API mirrors scikit-image for image manipulation and OpenSlide for image loading.</p>
           <a href="https://github.com/rapidsai/cucim" target="_blank">GitHub <i class="fa-solid fa-arrow-up-right"></i>
           </a> <br>
           <a href="https://docs.rapids.ai/api/cucim/stable/" target="_blank">Documentation <i

--- a/layouts/page/ecosystem.html
+++ b/layouts/page/ecosystem.html
@@ -537,7 +537,7 @@
               target="_blank"> Maintainer Documentation Page <i class="fa-solid fa-arrow-up-right"></i> </a> </p>
         </div>
         <div class="col-md-6 py-3">
-          <h2><i class="fa-regular fa-code-pull-request"></i>Contribution Guides </h2>
+          <h2><i class="fa-regular fa-code-pull-request"></i> Contribution Guides </h2>
           <p>Open source projects stay healthy with active contributions. Overall contribution guides can be found on
             our <a href="https://docs.rapids.ai/contributing" target="_blank">Documentation</a>. Each RAPIDS repository
             also has helpful and


### PR DESCRIPTION
I noticed that all the libraries on the Ecosystem page mention their PyData (CPU) counterparts, except for cuCIM. This adds crucial information that improves user discovery.
