### PR TITLE
Fix zero-padded wheel versions

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -197,10 +197,10 @@ bash Miniforge3-$(uname)-$(uname -m).sh</code></pre>
                     <p>Install via the NVIDIA PyPI index:</p>
                     <pre class="highlight use-white-copy"><code>pip install \
   --extra-index-url=https://pypi.nvidia.com \
-  cudf-cu12==25.02.* \
-  dask-cudf-cu12==25.02.* \
-  cuml-cu12==25.02.* \
-  cugraph-cu12==25.02.*</code></pre>
+  cudf-cu12==25.2.* \
+  dask-cudf-cu12==25.2.* \
+  cuml-cu12==25.2.* \
+  cugraph-cu12==25.2.*</code></pre>
 
                     <h3 class="mt-6 text-white">Install with Docker</h3>
                     <p>Check that you have the <a href="https://docs.rapids.ai/install#docker" target="_blank">required


### PR DESCRIPTION
Update the docs to use non-zero-padded (PEP440) version format. See https://github.com/rapidsai/rapids.ai/pull/432#discussion_r1956766200