### PR TITLE
Fix Open Graph image tag for better social media previews

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -19,7 +19,8 @@ params:
   title: RAPIDS | GPU Accelerated Data Science
   description: Open source GPU accelerated data science libraries
   images:
-    - /assets/images/rapids_logo.png
+    # This is used for the Open Graph preview on social media
+    - /assets/og_image.png
   social:
     twitter: rapidsai
 

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -19,7 +19,7 @@ params:
   title: RAPIDS | GPU Accelerated Data Science
   description: Open source GPU accelerated data science libraries
   images:
-    - /images/RAPIDS-logo-white.png
+    - /assets/images/rapids_logo.png
   social:
     twitter: rapidsai
 

--- a/layouts/partials/hooks/head-end.html
+++ b/layouts/partials/hooks/head-end.html
@@ -14,7 +14,7 @@
 <script type="text/javascript">
 function OptanonWrapper() {
         var event = new Event('bannerLoaded');
-        
+
         window.dispatchEvent(event);
 }
 </script>


### PR DESCRIPTION
This fixes the Open Graph image tag of our site's metadata to improve social media previews.
