### PR TITLE
Remove cuSpatial references

### DIFF
--- a/content/user-guides/library-guides.md
+++ b/content/user-guides/library-guides.md
@@ -48,11 +48,6 @@ Start with the [Easy Path](/api/cugraph/stable/basics/nx_transition/#easy-path-u
 {: .mb-8 }
 
 
-### <i class="fa-light fa-location-crosshairs"></i> Spatial Analytics with [cuSpatial](https://github.com/rapidsai/cuspatial){: target="_blank"}
-Start with the [cuSpatial User Guide](/api/cuspatial/stable/user_guide/cuspatial_api_examples/){: target="_blank"} for an intro to GPU Accelerated Spatial Analytics. The [demo notebooks](https://github.com/rapidsai/cuspatial/tree/branch-{{ site.data.releases.stable.version }}/python/cuspatial/demos) are also a good showcase.
-{: .mb-8 }
-
-
 ### <i class="fa-light fa-chart-scatter-bubble"></i> Accelerated Cross-filtered Dashboards with [cuxfilter](https://github.com/rapidsai/cuxfilter)
 Start with [10 Minutes to Cuxfilter](/api/cuxfilter/stable/10_minutes_to_cuxfilter/){: target="_blank"} to get an overview of how to quickly create a dashboard and [the examples section](/api/cuxfilter/stable/examples/examples/){: target="_blank"} for real dataset examples.
 {: .mb-8 }

--- a/content/user-guides/visualization.md
+++ b/content/user-guides/visualization.md
@@ -31,7 +31,7 @@ RAPIDS libraries can easily fit in visualization workflows. This catalog of feat
 
 ### GPU Accelerated Interaction
 
-The below libraries directly use RAPIDS cuDF/Dask-cuDF and/or cuSpatial to create charts that support accelerated crossfiltering or rendering:
+The below libraries directly use RAPIDS cuDF/Dask-cuDF to create charts that support accelerated crossfiltering or rendering:
 - **[Holoviews with Linked Brushing User Guide](https://holoviews.org/user_guide/Linked_Brushing.html?highlight=linked%20brushing)**
 - **[Datashader User Guide](https://datashader.org/user_guide/Performance.html)**
 - **[Plotly Dash with Holoviews Docs](https://dash.plotly.com/holoviews#gpu-accelerating-datashader-and-linked-selections-with-rapids)**

--- a/layouts/page/ecosystem.html
+++ b/layouts/page/ecosystem.html
@@ -142,31 +142,6 @@
       </div>
       <div class="row">
         <div class="col-md-4 py-3">
-          <h2 class="text-white"><i class="fa-regular fa-terminal"></i> cuSpatial</h2>
-          <div class="tags-container border-top border-2 border-white">
-            <span class="tags-item text-white border-white"><i class="fa-solid fa-tag"></i> GEOPANDAS </span>
-            <span class="tags-item text-white border-white"><i class="fa-solid fa-tag"></i> GEOSPATIAL </span>
-            <span class="tags-item text-white border-white"><i class="fa-solid fa-tag"></i> PYTHON / C++ </span>
-          </div>
-          <p class="text-white">cuSpatial is a library for lightning-fast spatial analytics. Fully integrated with
-            GeoPandas and growing fast, this toolkit will feel familiar to Python users of GIS tools.</p>
-          <a href="https://github.com/rapidsai/cuspatial" target="_blank">GitHub <i
-              class="fa-solid fa-arrow-up-right"></i> </a> <br>
-          <a href="https://docs.rapids.ai/api/cuspatial/stable/" target="_blank">Documentation <i
-              class="fa-solid fa-arrow-up-right"></i> </a> <br>
-          <a href="https://github.com/orgs/rapidsai/projects/41/views/5" target="_blank">Roadmap <i
-              class="fa-solid fa-arrow-up-right"></i> </a>
-
-          <br><br>
-
-          <h3 class="text-white">libcuspatial</h3>
-          <p class="text-white">libcuspatial provides the CUDA C++ building blocks powering cuSpatial.</p>
-          <a href="https://github.com/rapidsai/cuspatial" target="_blank">GitHub <i
-              class="fa-solid fa-arrow-up-right"></i> </a> <br>
-          <a href="https://docs.rapids.ai/api/libcuspatial/stable" target="_blank">Documentation <i
-              class="fa-solid fa-arrow-up-right"></i> </a>
-        </div>
-        <div class="col-md-4 py-3">
           <h2 class="text-white"><i class="fa-regular fa-terminal"></i> cuVS </h2>
           <div class="tags-container border-top border-2 border-white">
             <span class="tags-item text-white border-white"><i class="fa-solid fa-tag"></i> VECTOR SEARCH </span>
@@ -195,11 +170,8 @@
           <a href="https://docs.rapids.ai/api/raft/stable" target="_blank">Documentation <i
               class="fa-solid fa-arrow-up-right"></i> </a>
         </div>
-      </div>
-
-      <div class="row">
         <div class="col-md-4 py-3">
-          <h2 class="text-white"><i class="fa-regular fa-terminal"></i> kvikIO </h2>
+          <h2 class="text-white"><i class="fa-regular fa-terminal"></i> KvikIO </h2>
           <div class="tags-container border-top border-2 border-white">
             <span class="tags-item text-white border-white"><i class="fa-solid fa-tag"></i> FILE IO </span>
             <span class="tags-item text-white border-white"><i class="fa-solid fa-tag"></i> GPU DIRECT STORAGE </span>
@@ -221,6 +193,9 @@
           <a href="https://docs.rapids.ai/api/libkvikio/stable" target="_blank">Documentation <i
               class="fa-solid fa-arrow-up-right"></i> </a>
         </div>
+      </div>
+
+      <div class="row">
         <div class="col-md-4 py-3">
           <h2 class="text-white"><i class="fa-regular fa-terminal"></i> cuxfilter </h2>
           <div class="tags-container border-top border-2 border-white">

--- a/layouts/page/learn-more.html
+++ b/layouts/page/learn-more.html
@@ -67,8 +67,6 @@
               target="_blank">cuML</a> (similar API to scikit-learn) <br>
             <i class="fa fa-caret-right"></i> Graph processing with <a href="https://github.com/rapidsai/cugraph"
               target="_blank">cuGraph</a> (similar API to networkX) <br>
-            <i class="fa fa-caret-right"></i> Spatial analytics with <a href="https://github.com/rapidsai/cuspatial"
-              target="_blank">cuSpatial</a> (similar API to geoPandas) <br>
             <i class="fa fa-caret-right"></i> Image processing with <a href="https://github.com/rapidsai/cucim"
               target="_blank">cuCIM</a> (similar API to scikit-image) <br>
             <i class="fa fa-caret-right"></i> Seamless cross-filtered dashboards with <a


### PR DESCRIPTION
This PR removes cuSpatial from the lists of supported RAPIDS libraries.

See https://github.com/rapidsai/build-planning/issues/197.
