### PR TITLE
feat(renovate): add 7-day cooldown before any updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,15 @@
   "extends": [
     "config:recommended"
   ],
+  "packageRules": [
+    {
+      "description": "Wait for 7 days post-release before updating",
+      "matchPackageNames": [
+        "*"
+      ],
+      "minimumReleaseAge": "7 days"
+    }
+  ],
   "schedule": [
     "before 4am on the first day of the month"
   ]


### PR DESCRIPTION
Part of rapidsai/build-planning#273

Adds a 7-day cooldown period before renovate proposes any updates